### PR TITLE
Update Shiny Vault IDs

### DIFF
--- a/src/main/resources/cards/426-shiny_vault.yaml
+++ b/src/main/resources/cards/426-shiny_vault.yaml
@@ -5,8 +5,8 @@ set:
   enumId: SHINY_VAULT
   abbr: SMA
 cards:
-- id: 426-SV1
-  pioId: sma-SV1
+- id: 426-1
+  pioId: sma-1
   enumId: SCYTHER_SV1
   name: Scyther
   nationalPokedexNumber: 123
@@ -32,8 +32,8 @@ cards:
     value: x2
   rarity: Common
   artist: Shigenori Negishi
-- id: 426-SV10
-  pioId: sma-SV10
+- id: 426-10
+  pioId: sma-10
   enumId: QUAGSIRE_SV10
   name: Quagsire
   nationalPokedexNumber: 195
@@ -60,8 +60,8 @@ cards:
     value: x2
   rarity: Common
   artist: Saya Tsuruta
-- id: 426-SV11
-  pioId: sma-SV11
+- id: 426-11
+  pioId: sma-11
   enumId: FROAKIE_SV11
   name: Froakie
   nationalPokedexNumber: 656
@@ -85,8 +85,8 @@ cards:
     value: x2
   rarity: Common
   artist: sui
-- id: 426-SV12
-  pioId: sma-SV12
+- id: 426-12
+  pioId: sma-12
   enumId: FROGADIER_SV12
   name: Frogadier
   nationalPokedexNumber: 657
@@ -112,8 +112,8 @@ cards:
     value: x2
   rarity: Common
   artist: Anesaki Dynamic
-- id: 426-SV13
-  pioId: sma-SV13
+- id: 426-13
+  pioId: sma-13
   enumId: VOLTORB_SV13
   name: Voltorb
   nationalPokedexNumber: 100
@@ -141,8 +141,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Shin Nagasawa
-- id: 426-SV14
-  pioId: sma-SV14
+- id: 426-14
+  pioId: sma-14
   enumId: XURKITREE_SV14
   name: Xurkitree
   nationalPokedexNumber: 796
@@ -170,8 +170,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Naoki Saito
-- id: 426-SV15
-  pioId: sma-SV15
+- id: 426-15
+  pioId: sma-15
   enumId: SEVIPER_SV15
   name: Seviper
   nationalPokedexNumber: 336
@@ -195,8 +195,8 @@ cards:
     value: x2
   rarity: Common
   artist: SATOSHI NAKAI
-- id: 426-SV16
-  pioId: sma-SV16
+- id: 426-16
+  pioId: sma-16
   enumId: SHUPPET_SV16
   name: Shuppet
   nationalPokedexNumber: 353
@@ -222,8 +222,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: sui
-- id: 426-SV17
-  pioId: sma-SV17
+- id: 426-17
+  pioId: sma-17
   enumId: INKAY_SV17
   name: Inkay
   nationalPokedexNumber: 686
@@ -243,8 +243,8 @@ cards:
     value: x2
   rarity: Common
   artist: Shigenori Negishi
-- id: 426-SV18
-  pioId: sma-SV18
+- id: 426-18
+  pioId: sma-18
   enumId: MALAMAR_SV18
   name: Malamar
   nationalPokedexNumber: 687
@@ -269,8 +269,8 @@ cards:
     value: x2
   rarity: Common
   artist: Hideki Ishikawa
-- id: 426-SV19
-  pioId: sma-SV19
+- id: 426-19
+  pioId: sma-19
   enumId: POIPOLE_SV19
   name: Poipole
   nationalPokedexNumber: 803
@@ -293,8 +293,8 @@ cards:
     value: x2
   rarity: Common
   artist: Akira Komayama
-- id: 426-SV2
-  pioId: sma-SV2
+- id: 426-2
+  pioId: sma-2
   enumId: ROWLET_SV2
   name: Rowlet
   nationalPokedexNumber: 722
@@ -317,8 +317,8 @@ cards:
     value: x2
   rarity: Common
   artist: sui
-- id: 426-SV20
-  pioId: sma-SV20
+- id: 426-20
+  pioId: sma-20
   enumId: SUDOWOODO_SV20
   name: Sudowoodo
   nationalPokedexNumber: 185
@@ -344,8 +344,8 @@ cards:
     value: x2
   rarity: Common
   artist: Kyoko Umemoto
-- id: 426-SV21
-  pioId: sma-SV21
+- id: 426-21
+  pioId: sma-21
   enumId: RIOLU_SV21
   name: Riolu
   nationalPokedexNumber: 447
@@ -369,8 +369,8 @@ cards:
     value: x2
   rarity: Common
   artist: Misa Tsutsui
-- id: 426-SV22
-  pioId: sma-SV22
+- id: 426-22
+  pioId: sma-22
   enumId: LUCARIO_SV22
   name: Lucario
   nationalPokedexNumber: 448
@@ -397,8 +397,8 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: 426-SV23
-  pioId: sma-SV23
+- id: 426-23
+  pioId: sma-23
   enumId: ROCKRUFF_SV23
   name: Rockruff
   nationalPokedexNumber: 744
@@ -419,8 +419,8 @@ cards:
     value: x2
   rarity: Common
   artist: Masakazu Fukuda
-- id: 426-SV24
-  pioId: sma-SV24
+- id: 426-24
+  pioId: sma-24
   enumId: BUZZWOLE_SV24
   name: Buzzwole
   nationalPokedexNumber: 794
@@ -445,8 +445,8 @@ cards:
     value: x2
   rarity: Common
   artist: Shin Nagasawa
-- id: 426-SV25
-  pioId: sma-SV25
+- id: 426-25
+  pioId: sma-25
   enumId: ZORUA_SV25
   name: Zorua
   nationalPokedexNumber: 570
@@ -472,8 +472,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Saya Tsuruta
-- id: 426-SV26
-  pioId: sma-SV26
+- id: 426-26
+  pioId: sma-26
   enumId: GUZZLORD_SV26
   name: Guzzlord
   nationalPokedexNumber: 799
@@ -497,8 +497,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Masakazu Fukuda
-- id: 426-SV27
-  pioId: sma-SV27
+- id: 426-27
+  pioId: sma-27
   enumId: MAGNEMITE_SV27
   name: Magnemite
   nationalPokedexNumber: 81
@@ -525,8 +525,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: SATOSHI NAKAI
-- id: 426-SV28
-  pioId: sma-SV28
+- id: 426-28
+  pioId: sma-28
   enumId: MAGNETON_SV28
   name: Magneton
   nationalPokedexNumber: 82
@@ -554,8 +554,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Kyoko Umemoto
-- id: 426-SV29
-  pioId: sma-SV29
+- id: 426-29
+  pioId: sma-29
   enumId: MAGNEZONE_SV29
   name: Magnezone
   nationalPokedexNumber: 462
@@ -584,8 +584,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Misa Tsutsui
-- id: 426-SV3
-  pioId: sma-SV3
+- id: 426-3
+  pioId: sma-3
   enumId: DARTRIX_SV3
   name: Dartrix
   nationalPokedexNumber: 723
@@ -611,8 +611,8 @@ cards:
     value: x2
   rarity: Common
   artist: Shigenori Negishi
-- id: 426-SV30
-  pioId: sma-SV30
+- id: 426-30
+  pioId: sma-30
   enumId: BELDUM_SV30
   name: Beldum
   nationalPokedexNumber: 374
@@ -636,8 +636,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Mizue
-- id: 426-SV31
-  pioId: sma-SV31
+- id: 426-31
+  pioId: sma-31
   enumId: METANG_SV31
   name: Metang
   nationalPokedexNumber: 375
@@ -665,8 +665,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Saya Tsuruta
-- id: 426-SV32
-  pioId: sma-SV32
+- id: 426-32
+  pioId: sma-32
   enumId: CELESTEELA_SV32
   name: Celesteela
   nationalPokedexNumber: 797
@@ -690,8 +690,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Kouki Saitou
-- id: 426-SV33
-  pioId: sma-SV33
+- id: 426-33
+  pioId: sma-33
   enumId: KARTANA_SV33
   name: Kartana
   nationalPokedexNumber: 798
@@ -715,8 +715,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Anesaki Dynamic
-- id: 426-SV34
-  pioId: sma-SV34
+- id: 426-34
+  pioId: sma-34
   enumId: RALTS_SV34
   name: Ralts
   nationalPokedexNumber: 280
@@ -740,8 +740,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Kyoko Umemoto
-- id: 426-SV35
-  pioId: sma-SV35
+- id: 426-35
+  pioId: sma-35
   enumId: KIRLIA_SV35
   name: Kirlia
   nationalPokedexNumber: 281
@@ -768,8 +768,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Sumiyoshi Kizuki
-- id: 426-SV36
-  pioId: sma-SV36
+- id: 426-36
+  pioId: sma-36
   enumId: DIANCIE_SV36
   name: Diancie
   nationalPokedexNumber: 719
@@ -796,8 +796,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Akira Komayama
-- id: 426-SV37
-  pioId: sma-SV37
+- id: 426-37
+  pioId: sma-37
   enumId: ALTARIA_SV37
   name: Altaria
   nationalPokedexNumber: 334
@@ -822,8 +822,8 @@ cards:
     value: x2
   rarity: Common
   artist: kirisAki
-- id: 426-SV38
-  pioId: sma-SV38
+- id: 426-38
+  pioId: sma-38
   enumId: GIBLE_SV38
   name: Gible
   nationalPokedexNumber: 443
@@ -844,8 +844,8 @@ cards:
     value: x2
   rarity: Common
   artist: Saya Tsuruta
-- id: 426-SV39
-  pioId: sma-SV39
+- id: 426-39
+  pioId: sma-39
   enumId: GABITE_SV39
   name: Gabite
   nationalPokedexNumber: 444
@@ -870,8 +870,8 @@ cards:
     value: x2
   rarity: Common
   artist: Masakazu Fukuda
-- id: 426-SV4
-  pioId: sma-SV4
+- id: 426-4
+  pioId: sma-4
   enumId: WIMPOD_SV4
   name: Wimpod
   nationalPokedexNumber: 767
@@ -895,8 +895,8 @@ cards:
     value: x2
   rarity: Common
   artist: SATOSHI NAKAI
-- id: 426-SV40
-  pioId: sma-SV40
+- id: 426-40
+  pioId: sma-40
   enumId: GARCHOMP_SV40
   name: Garchomp
   nationalPokedexNumber: 445
@@ -921,8 +921,8 @@ cards:
     value: x2
   rarity: Common
   artist: Shin Nagasawa
-- id: 426-SV41
-  pioId: sma-SV41
+- id: 426-41
+  pioId: sma-41
   enumId: EEVEE_SV41
   name: Eevee
   nationalPokedexNumber: 133
@@ -949,8 +949,8 @@ cards:
     value: x2
   rarity: Common
   artist: kirisAki
-- id: 426-SV42
-  pioId: sma-SV42
+- id: 426-42
+  pioId: sma-42
   enumId: SWABLU_SV42
   name: Swablu
   nationalPokedexNumber: 333
@@ -976,8 +976,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Shigenori Negishi
-- id: 426-SV43
-  pioId: sma-SV43
+- id: 426-43
+  pioId: sma-43
   enumId: NOIBAT_SV43
   name: Noibat
   nationalPokedexNumber: 714
@@ -1002,8 +1002,8 @@ cards:
     value: '-20'
   rarity: Common
   artist: Mizue
-- id: 426-SV44
-  pioId: sma-SV44
+- id: 426-44
+  pioId: sma-44
   enumId: ORANGURU_SV44
   name: Oranguru
   nationalPokedexNumber: 765
@@ -1029,8 +1029,8 @@ cards:
     value: x2
   rarity: Common
   artist: Akira Komayama
-- id: 426-SV45
-  pioId: sma-SV45
+- id: 426-45
+  pioId: sma-45
   enumId: TYPE_NULL_SV45
   name: 'Type: Null'
   number: SV45
@@ -1053,8 +1053,8 @@ cards:
     value: x2
   rarity: Common
   artist: Shin Nagasawa
-- id: 426-SV46
-  pioId: sma-SV46
+- id: 426-46
+  pioId: sma-46
   enumId: LEAFEON_GX_SV46
   name: Leafeon-GX
   nationalPokedexNumber: 470
@@ -1086,8 +1086,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV47
-  pioId: sma-SV47
+- id: 426-47
+  pioId: sma-47
   enumId: DECIDUEYE_GX_SV47
   name: Decidueye-GX
   nationalPokedexNumber: 724
@@ -1117,8 +1117,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV48
-  pioId: sma-SV48
+- id: 426-48
+  pioId: sma-48
   enumId: GOLISOPOD_GX_SV48
   name: Golisopod-GX
   nationalPokedexNumber: 768
@@ -1151,8 +1151,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV49
-  pioId: sma-SV49
+- id: 426-49
+  pioId: sma-49
   enumId: CHARIZARD_GX_SV49
   name: Charizard-GX
   nationalPokedexNumber: 6
@@ -1181,8 +1181,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV5
-  pioId: sma-SV5
+- id: 426-5
+  pioId: sma-5
   enumId: PHEROMOSA_SV5
   name: Pheromosa
   nationalPokedexNumber: 795
@@ -1204,8 +1204,8 @@ cards:
     value: x2
   rarity: Common
   artist: Mizue
-- id: 426-SV50
-  pioId: sma-SV50
+- id: 426-50
+  pioId: sma-50
   enumId: HO_OH_GX_SV50
   name: Ho-Oh-GX
   nationalPokedexNumber: 250
@@ -1237,8 +1237,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV51
-  pioId: sma-SV51
+- id: 426-51
+  pioId: sma-51
   enumId: RESHIRAM_GX_SV51
   name: Reshiram-GX
   nationalPokedexNumber: 643
@@ -1268,8 +1268,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: PLANETA Igarashi
-- id: 426-SV52
-  pioId: sma-SV52
+- id: 426-52
+  pioId: sma-52
   enumId: TURTONATOR_GX_SV52
   name: Turtonator-GX
   nationalPokedexNumber: 776
@@ -1300,8 +1300,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV53
-  pioId: sma-SV53
+- id: 426-53
+  pioId: sma-53
   enumId: ALOLAN_NINETALES_GX_SV53
   name: Alolan Ninetales-GX
   nationalPokedexNumber: 38
@@ -1331,8 +1331,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV54
-  pioId: sma-SV54
+- id: 426-54
+  pioId: sma-54
   enumId: ARTICUNO_GX_SV54
   name: Articuno-GX
   nationalPokedexNumber: 144
@@ -1362,8 +1362,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV55
-  pioId: sma-SV55
+- id: 426-55
+  pioId: sma-55
   enumId: GLACEON_GX_SV55
   name: Glaceon-GX
   nationalPokedexNumber: 471
@@ -1397,8 +1397,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV56
-  pioId: sma-SV56
+- id: 426-56
+  pioId: sma-56
   enumId: GRENINJA_GX_SV56
   name: Greninja-GX
   nationalPokedexNumber: 658
@@ -1430,8 +1430,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV57
-  pioId: sma-SV57
+- id: 426-57
+  pioId: sma-57
   enumId: ELECTRODE_GX_SV57
   name: Electrode-GX
   nationalPokedexNumber: 101
@@ -1467,8 +1467,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV58
-  pioId: sma-SV58
+- id: 426-58
+  pioId: sma-58
   enumId: XURKITREE_GX_SV58
   name: Xurkitree-GX
   nationalPokedexNumber: 796
@@ -1501,8 +1501,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV59
-  pioId: sma-SV59
+- id: 426-59
+  pioId: sma-59
   enumId: MEWTWO_GX_SV59
   name: Mewtwo-GX
   nationalPokedexNumber: 150
@@ -1532,8 +1532,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV6
-  pioId: sma-SV6
+- id: 426-6
+  pioId: sma-6
   enumId: CHARMANDER_SV6
   name: Charmander
   nationalPokedexNumber: 4
@@ -1554,8 +1554,8 @@ cards:
     value: x2
   rarity: Common
   artist: kirisAki
-- id: 426-SV60
-  pioId: sma-SV60
+- id: 426-60
+  pioId: sma-60
   enumId: ESPEON_GX_SV60
   name: Espeon-GX
   nationalPokedexNumber: 196
@@ -1586,8 +1586,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV61
-  pioId: sma-SV61
+- id: 426-61
+  pioId: sma-61
   enumId: BANETTE_GX_SV61
   name: Banette-GX
   nationalPokedexNumber: 354
@@ -1622,8 +1622,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV62
-  pioId: sma-SV62
+- id: 426-62
+  pioId: sma-62
   enumId: NIHILEGO_GX_SV62
   name: Nihilego-GX
   nationalPokedexNumber: 793
@@ -1653,8 +1653,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV63
-  pioId: sma-SV63
+- id: 426-63
+  pioId: sma-63
   enumId: NAGANADEL_GX_SV63
   name: Naganadel-GX
   nationalPokedexNumber: 804
@@ -1685,8 +1685,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV64
-  pioId: sma-SV64
+- id: 426-64
+  pioId: sma-64
   enumId: LUCARIO_GX_SV64
   name: Lucario-GX
   nationalPokedexNumber: 448
@@ -1717,8 +1717,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV65
-  pioId: sma-SV65
+- id: 426-65
+  pioId: sma-65
   enumId: ZYGARDE_GX_SV65
   name: Zygarde-GX
   nationalPokedexNumber: 718
@@ -1748,8 +1748,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV66
-  pioId: sma-SV66
+- id: 426-66
+  pioId: sma-66
   enumId: LYCANROC_GX_SV66
   name: Lycanroc-GX
   nationalPokedexNumber: 745
@@ -1781,8 +1781,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV67
-  pioId: sma-SV67
+- id: 426-67
+  pioId: sma-67
   enumId: LYCANROC_GX_SV67
   name: Lycanroc-GX
   nationalPokedexNumber: 745
@@ -1813,8 +1813,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV68
-  pioId: sma-SV68
+- id: 426-68
+  pioId: sma-68
   enumId: BUZZWOLE_GX_SV68
   name: Buzzwole-GX
   nationalPokedexNumber: 794
@@ -1845,8 +1845,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV69
-  pioId: sma-SV69
+- id: 426-69
+  pioId: sma-69
   enumId: UMBREON_GX_SV69
   name: Umbreon-GX
   nationalPokedexNumber: 197
@@ -1880,8 +1880,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV7
-  pioId: sma-SV7
+- id: 426-7
+  pioId: sma-7
   enumId: CHARMELEON_SV7
   name: Charmeleon
   nationalPokedexNumber: 5
@@ -1909,8 +1909,8 @@ cards:
     value: x2
   rarity: Common
   artist: nagimiso
-- id: 426-SV70
-  pioId: sma-SV70
+- id: 426-70
+  pioId: sma-70
   enumId: DARKRAI_GX_SV70
   name: Darkrai-GX
   nationalPokedexNumber: 491
@@ -1944,8 +1944,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV71
-  pioId: sma-SV71
+- id: 426-71
+  pioId: sma-71
   enumId: GUZZLORD_GX_SV71
   name: Guzzlord-GX
   nationalPokedexNumber: 799
@@ -1977,8 +1977,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV72
-  pioId: sma-SV72
+- id: 426-72
+  pioId: sma-72
   enumId: SCIZOR_GX_SV72
   name: Scizor-GX
   nationalPokedexNumber: 212
@@ -2014,8 +2014,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV73
-  pioId: sma-SV73
+- id: 426-73
+  pioId: sma-73
   enumId: KARTANA_GX_SV73
   name: Kartana-GX
   nationalPokedexNumber: 798
@@ -2047,8 +2047,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV74
-  pioId: sma-SV74
+- id: 426-74
+  pioId: sma-74
   enumId: STAKATAKA_GX_SV74
   name: Stakataka-GX
   nationalPokedexNumber: 805
@@ -2081,8 +2081,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV75
-  pioId: sma-SV75
+- id: 426-75
+  pioId: sma-75
   enumId: GARDEVOIR_GX_SV75
   name: Gardevoir-GX
   nationalPokedexNumber: 282
@@ -2117,8 +2117,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV76
-  pioId: sma-SV76
+- id: 426-76
+  pioId: sma-76
   enumId: SYLVEON_GX_SV76
   name: Sylveon-GX
   nationalPokedexNumber: 700
@@ -2150,8 +2150,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV77
-  pioId: sma-SV77
+- id: 426-77
+  pioId: sma-77
   enumId: ALTARIA_GX_SV77
   name: Altaria-GX
   nationalPokedexNumber: 334
@@ -2183,8 +2183,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV78
-  pioId: sma-SV78
+- id: 426-78
+  pioId: sma-78
   enumId: NOIVERN_GX_SV78
   name: Noivern-GX
   nationalPokedexNumber: 715
@@ -2216,8 +2216,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV79
-  pioId: sma-SV79
+- id: 426-79
+  pioId: sma-79
   enumId: SILVALLY_GX_SV79
   name: Silvally-GX
   nationalPokedexNumber: 773
@@ -2248,8 +2248,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV8
-  pioId: sma-SV8
+- id: 426-8
+  pioId: sma-8
   enumId: ALOLAN_VULPIX_SV8
   name: Alolan Vulpix
   nationalPokedexNumber: 37
@@ -2273,8 +2273,8 @@ cards:
     value: x2
   rarity: Common
   artist: Kouki Saitou
-- id: 426-SV80
-  pioId: sma-SV80
+- id: 426-80
+  pioId: sma-80
   enumId: DRAMPA_GX_SV80
   name: Drampa-GX
   nationalPokedexNumber: 780
@@ -2304,8 +2304,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV81
-  pioId: sma-SV81
+- id: 426-81
+  pioId: sma-81
   enumId: AETHER_FOUNDATION_EMPLOYEE_SV81
   name: Aether Foundation Employee
   number: SV81
@@ -2315,8 +2315,8 @@ cards:
   text: [Put 3 Pokémon that have "Alolan" in their names from your discard pile into
       your hand.]
   artist: take
-- id: 426-SV82
-  pioId: sma-SV82
+- id: 426-82
+  pioId: sma-82
   enumId: CYNTHIA_SV82
   name: Cynthia
   number: SV82
@@ -2325,8 +2325,8 @@ cards:
   rarity: Common
   text: ['Shuffle your hand into your deck. Then, draw 6 cards.']
   artist: Yusuke Ohmura
-- id: 426-SV83
-  pioId: sma-SV83
+- id: 426-83
+  pioId: sma-83
   enumId: FISHERMAN_SV83
   name: Fisherman
   number: SV83
@@ -2335,8 +2335,8 @@ cards:
   rarity: Common
   text: [Put 4 basic Energy cards from your discard pile into your hand.]
   artist: Masakazu Fukuda
-- id: 426-SV84
-  pioId: sma-SV84
+- id: 426-84
+  pioId: sma-84
   enumId: GUZMA_SV84
   name: Guzma
   number: SV84
@@ -2346,8 +2346,8 @@ cards:
   text: ['Switch 1 of your opponent''s Benched Pokémon with their Active Pokémon.
       If you do, switch your Active Pokémon with 1 of your Benched Pokémon.']
   artist: Hitoshi Ariga
-- id: 426-SV85
-  pioId: sma-SV85
+- id: 426-85
+  pioId: sma-85
   enumId: HIKER_SV85
   name: Hiker
   number: SV85
@@ -2358,8 +2358,8 @@ cards:
       player shuffles the other cards back into their deck. Then, put the card you
       chose on top of that deck.']
   artist: Naoki Saito
-- id: 426-SV86
-  pioId: sma-SV86
+- id: 426-86
+  pioId: sma-86
   enumId: LADY_SV86
   name: Lady
   number: SV86
@@ -2369,8 +2369,8 @@ cards:
   text: ['Search your deck for up to 4 basic Energy cards, reveal them, and put them
       into your hand. Then, shuffle your deck.']
   artist: Kanako Eo
-- id: 426-SV87
-  pioId: sma-SV87
+- id: 426-87
+  pioId: sma-87
   enumId: AETHER_PARADISE_CONSERVATION_AREA_SV87
   name: Aether Paradise Conservation Area
   number: SV87
@@ -2381,8 +2381,8 @@ cards:
       take 30 less damage from the opponent''s attacks (after applying Weakness and
       Resistance).']
   artist: 5ban Graphics
-- id: 426-SV88
-  pioId: sma-SV88
+- id: 426-88
+  pioId: sma-88
   enumId: BROOKLET_HILL_SV88
   name: Brooklet Hill
   number: SV88
@@ -2393,8 +2393,8 @@ cards:
       Basic [W] Pokémon or Basic [F] Pokémon, put it onto their Bench, and shuffle
       their deck.']
   artist: 5ban Graphics
-- id: 426-SV89
-  pioId: sma-SV89
+- id: 426-89
+  pioId: sma-89
   enumId: MT_CORONET_SV89
   name: Mt. Coronet
   number: SV89
@@ -2404,8 +2404,8 @@ cards:
   text: ['Once during each player''s turn, that player may put 2 [M] Energy cards
       from their discard pile into their hand.']
   artist: 5ban Graphics
-- id: 426-SV9
-  pioId: sma-SV9
+- id: 426-9
+  pioId: sma-9
   enumId: WOOPER_SV9
   name: Wooper
   nationalPokedexNumber: 194
@@ -2428,8 +2428,8 @@ cards:
     value: x2
   rarity: Common
   artist: Misa Tsutsui
-- id: 426-SV90
-  pioId: sma-SV90
+- id: 426-90
+  pioId: sma-90
   enumId: SHRINE_OF_PUNISHMENT_SV90
   name: Shrine of Punishment
   number: SV90
@@ -2439,8 +2439,8 @@ cards:
   text: ['Between turns, put 1 damage counter on each Pokémon-GX and Pokémon-EX (both
       yours and your opponent''s).']
   artist: 5ban Graphics
-- id: 426-SV91
-  pioId: sma-SV91
+- id: 426-91
+  pioId: sma-91
   enumId: TAPU_BULU_GX_SV91
   name: Tapu Bulu-GX
   number: SV91
@@ -2466,8 +2466,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV92
-  pioId: sma-SV92
+- id: 426-92
+  pioId: sma-92
   enumId: TAPU_FINI_GX_SV92
   name: Tapu Fini-GX
   number: SV92
@@ -2494,8 +2494,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV93
-  pioId: sma-SV93
+- id: 426-93
+  pioId: sma-93
   enumId: TAPU_KOKO_GX_SV93
   name: Tapu Koko-GX
   number: SV93
@@ -2522,8 +2522,8 @@ cards:
   rarity: Common
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 426-SV94
-  pioId: sma-SV94
+- id: 426-94
+  pioId: sma-94
   enumId: TAPU_LELE_GX_SV94
   name: Tapu Lele-GX
   number: SV94


### PR DESCRIPTION
Previously the IDs would have `SV` prefix in them.  This PR removes them to keep the formatting consistent with the other sets.