### PR TITLE
Re-order and add missing Sun and Moon promos

### DIFF
--- a/src/main/resources/cards/410-sun_moon_promos.yaml
+++ b/src/main/resources/cards/410-sun_moon_promos.yaml
@@ -2871,6 +2871,7 @@ cards:
   - type: G
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: Shin Nagasawa
 - id: 410-SM106
   pioId: smp-SM106
@@ -3338,6 +3339,7 @@ cards:
   - type: G
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
 - id: 410-SM123
   pioId: smp-SM123
@@ -3622,6 +3624,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
 - id: 410-SM134
   pioId: smp-SM134
@@ -3655,6 +3658,7 @@ cards:
   - type: F
     value: '-20'
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
 - id: 410-SM135
   pioId: smp-SM135
@@ -3735,6 +3739,7 @@ cards:
   - type: W
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM138
   pioId: smp-SM138
   enumId: ZEKROM_GX_SM138
@@ -3767,6 +3772,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM139
   pioId: smp-SM139
   enumId: SALAMENCE_GX_SM139
@@ -3796,6 +3802,7 @@ cards:
   - type: Y
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM140
   pioId: smp-SM140
   enumId: SALAMENCE_SM140
@@ -3851,6 +3858,7 @@ cards:
   - type: Y
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM142
   pioId: smp-SM142
   enumId: KYUREM_SM142
@@ -4624,6 +4632,7 @@ cards:
   - type: W
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM172
   pioId: smp-SM172
   enumId: VAPOREON_GX_SM172
@@ -4654,6 +4663,7 @@ cards:
   - type: G
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM173
   pioId: smp-SM173
   enumId: JOLTEON_GX_SM173
@@ -4686,6 +4696,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM174
   pioId: smp-SM174
   enumId: EEVEE_GX_SM174
@@ -4715,6 +4726,7 @@ cards:
   - type: F
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM175
   pioId: smp-SM175
   enumId: EEVEE_GX_SM175
@@ -4744,8 +4756,7 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-  copyOf: 410-SM174
-  copyType: Reprint
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM176
   pioId: smp-SM176
   enumId: EEVEE_GX_SM176
@@ -4775,8 +4786,7 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-  copyOf: 410-SM174
-  copyType: Reprint
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM177
   pioId: smp-SM177
   enumId: MELTAN_SM177
@@ -4835,6 +4845,7 @@ cards:
   - type: P
     value: '-20'
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM179
   pioId: smp-SM179
   enumId: VOLCANION_SM179
@@ -5058,6 +5069,7 @@ cards:
   - type: W
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM188
   pioId: smp-SM188
   enumId: KANGASKHAN_GX_SM188
@@ -5086,6 +5098,7 @@ cards:
   - type: F
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']  
 - id: 410-SM189
   pioId: smp-SM189
   enumId: BLASTOISE_GX_SM189
@@ -5116,6 +5129,7 @@ cards:
   - type: G
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM190
   pioId: smp-SM190
   enumId: DETECTIVE_PIKACHU_SM190
@@ -5280,6 +5294,7 @@ cards:
   - type: W
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM196
   pioId: smp-SM196
   enumId: MEWTWO_GX_SM196
@@ -5308,6 +5323,7 @@ cards:
   - type: P
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM197
   pioId: smp-SM197
   enumId: GRENINJA_GX_SM197
@@ -5338,6 +5354,7 @@ cards:
   - type: G
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM198
   pioId: smp-SM198
   enumId: BULBASAUR_SM198
@@ -5625,8 +5642,6 @@ cards:
   - type: G
     value: x2
   rarity: Promo
-  copyOf: 410-SM180
-  copyType: Reprint
 - id: 410-SM210
   pioId: smp-SM210
   enumId: MOLTRES_ZAPDOS_ARTICUNO_GX_SM210
@@ -5678,6 +5693,7 @@ cards:
   - type: W
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM212
   pioId: smp-SM212
   enumId: GYARADOS_GX_SM212
@@ -5701,6 +5717,7 @@ cards:
   - type: L
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM213
   pioId: smp-SM213
   enumId: RAICHU_GX_SM213
@@ -5727,6 +5744,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM214
   pioId: smp-SM214
   enumId: MEWTWO_SM214
@@ -5803,6 +5821,7 @@ cards:
   - type: F
     value: x2
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM217
   pioId: smp-SM217
   enumId: TREVENANT_DUSKNOIR_GX_SM217
@@ -5979,8 +5998,6 @@ cards:
   - type: G
     value: x2
   rarity: Promo
-  copyOf: 410-SM205
-  copyType: Reprint
 - id: 410-SM224
   pioId: smp-SM224
   enumId: CELEBI_SM224
@@ -6053,8 +6070,6 @@ cards:
   - type: W
     value: x2
   rarity: Promo
-  copyOf: 410-SM158
-  copyType: Reprint
 - id: 410-SM227
   pioId: smp-SM227
   enumId: PIKACHU_SM227
@@ -6166,8 +6181,6 @@ cards:
   rarity: Promo
   text: ['Once during each player''s turn, if that player has 6 Pokémon in play, he
       or she may heal 10 damage from each of his or her Pokémon.']
-  copyOf: 410-SM148
-  copyType: Reprint
 - id: 410-SM232
   pioId: smp-SM232
   enumId: PIKACHU_GX_SM232
@@ -6200,6 +6213,7 @@ cards:
   - type: M
     value: '-20'
   rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM233
   pioId: smp-SM233
   enumId: EEVEE_GX_SM233
@@ -6229,8 +6243,7 @@ cards:
   - type: F
     value: x2
   rarity: Promo
-  copyOf: 410-SM174
-  copyType: Reprint
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
 - id: 410-SM234
   pioId: smp-SM234
   enumId: PIKACHU_SM234
@@ -6303,5 +6316,192 @@ cards:
       Pokémon.) (You can't use more than 1 GX attack in a game.)
   weaknesses:
   - type: M
+    value: x2
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+- id: 410-SM237
+  pioId: smp-SM237
+  enumId: LEAFEON_SM237
+  name: Leafeon
+  number: SM237
+  types: [G]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, EVOLUTION, STAGE1]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [G]
+    name: Aromax
+    text: Heal all damage from 1 of your Benched Pokémon.
+  - cost: [G, C, C]
+    name: Leaf Blade
+    damage: '80+'
+    text: Flip a coin. If heads, this attack does 40 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 410-SM238
+  pioId: smp-SM238
+  enumId: GLACEON_SM238
+  name: Glaceon
+  number: SM238
+  types: [W]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, EVOLUTION, STAGE1]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Snow Cloak
+    damage: '30'
+    text: Flip a coin. If heads, prevent all effects of attacks, including damage,
+      done to this Pokémon during your opponent's next turn.
+  - cost: [W, W, C]
+    name: Hypnotic Blizzard
+    damage: '90'
+    text: Your opponent's active Pokémon is now Asleep. This attack does 20 damage
+      to each of your opponent's Benched Pokémon. (Don't apply Weakness and
+      Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+- id: 410-SM239
+  pioId: smp-SM239
+  enumId: CARRACOSTA_GX_SM239
+  name: Carracosta-GX
+  number: SM239
+  types: [F]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, EVOLUTION, POKEMON_GX, STAGE2]
+  evolvesFrom: Tirtouga
+  hp: 250
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: High Density Armor
+    text: If this Pokémon has full HP, it takes 90 less damage from your opponent’s
+      attacks (after applying Weakness and Resistance).
+  moves:
+  - cost: [F, C, C, C]
+    damage: '160'
+    name: Ground Crush
+    text: The Defending Pokémon can’t retreat during your opponent’s next turn.
+  - cost: [C]
+    name: Stone Age GX
+    text: Put any number of Pokémon that evolve from Unidentified Fossil from your
+      discard pile onto your Bench. (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+- id: 410-SM240
+  pioId: smp-SM240
+  enumId: ESPEON_DEOXYS_GX_SM240
+  name: Espeon & Deoxys-GX
+  number: SM240
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 260
+  retreatCost: 2
+  moves:
+  - cost: [P, C, C]
+    name: Psychic Club
+    damage: 10+
+    text: This attack does 30 more damage for each of your Benched [P] Pokémon.
+  - cost: [P, C, C]
+    name: Cross Division GX
+    text: Put 10 damage counters on your opponent's Pokémon in any way you like. If
+      this Pokémon has at least 3 extra Energy attached to it (in addition to this
+      attack's cost), put 20 damage counters on them instead. (You can’t use more
+      than 1 GX attack in a game.)
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+- id: 410-SM241
+  pioId: smp-SM241
+  enumId: UMBREON_DARKRAI_GX_SM241
+  name: Umbreon & Darkrai-GX
+  number: 'SM241'
+  types: [D]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 270
+  retreatCost: 2
+  moves:
+  - cost: [D, D, C]
+    name: Black Lance
+    damage: '150'
+    text: This attack does 60 damage to 1 of your opponent’s Benched Pokémon-GX or
+      Benched Pokémon-EX. (Don’t apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [C]
+    name: Dark Moon GX
+    text: Your opponent can’t play any Trainer cards from their hand during their
+      next turn. If this Pokémon has at least 5 extra [D] Energy attached to it (in
+      addition to this attack’s cost), your opponent's Active Pokémon is Knocked Out.
+      (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+- id: 410-SM242
+  pioId: smp-SM242
+  enumId: EEVEE_GX_SM242
+  name: Eevee-GX
+  number: SM242
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 160
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Ascension DNA
+    text: Once during your turn (before your attack), if you have a Pokémon in your
+      hand that evolves from Eevee, you may put that card onto this Pokémon to evolve
+      it. Before evolving, heal all damage from this Pokémon. You can't use this Ability
+      during your first turn or the turn this Pokémon was put into play.
+  moves:
+  - cost: [C, C, C]
+    name: Boost Dash
+    damage: '100'
+  - cost: [C]
+    name: Joy Maker GX
+    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+      1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+- id: 410-SM243
+  pioId: smp-SM243
+  enumId: REGIGIGAS_SM243
+  name: Regigigas
+  number: SM243
+  types: [C]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 150
+  retreatCost: 4
+  moves:
+  - cost: [C, C, C]
+    name: Hammer In
+    damage: '60'
+  - cost: [W, F, M, C, C]
+    name: Regiblast
+    damage: '180'
+    text: Discard the top card of your opponent’s deck.
+  weaknesses:
+  - type: F
     value: x2
   rarity: Promo

--- a/src/main/resources/cards/410-sun_moon_promos.yaml
+++ b/src/main/resources/cards/410-sun_moon_promos.yaml
@@ -6339,7 +6339,7 @@ cards:
     damage: '80+'
     text: Flip a coin. If heads, this attack does 40 more damage.
   weaknesses:
-  - type: F
+  - type: R
     value: x2
   rarity: Promo
 - id: 410-SM238

--- a/src/main/resources/cards/410-sun_moon_promos.yaml
+++ b/src/main/resources/cards/410-sun_moon_promos.yaml
@@ -5034,7 +5034,7 @@ cards:
   number: SM187
   types: [R]
   superType: POKEMON
-  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
+  subTypes: [NOT_IMPLEMENTED, EVOLUTION, POKEMON_GX, STAGE1]
   evolvesFrom: Cubone
   hp: 200
   retreatCost: 2
@@ -5237,7 +5237,7 @@ cards:
   number: SM194
   types: [L]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [NOT_IMPLEMENTED, BASIC]
   hp: 90
   retreatCost: 2
   moves:
@@ -5259,7 +5259,7 @@ cards:
   number: SM195
   types: [R]
   superType: POKEMON
-  subTypes: [EVOLUTION, POKEMON_GX, STAGE2]
+  subTypes: [NOT_IMPLEMENTED, EVOLUTION, POKEMON_GX, STAGE2]
   evolvesFrom: Charmeleon
   hp: 250
   retreatCost: 4
@@ -5287,7 +5287,7 @@ cards:
   number: SM196
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [NOT_IMPLEMENTED, BASIC, POKEMON_GX]
   hp: 190
   retreatCost: 2
   moves:
@@ -5934,7 +5934,7 @@ cards:
   number: SM222
   types: [P]
   superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1]
+  subTypes: [NOT_IMPLEMENTED, EVOLUTION, STAGE1]
   evolvesFrom: Misdreavus
   hp: 110
   retreatCost: 1
@@ -5988,7 +5988,7 @@ cards:
   number: SM224
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [NOT_IMPLEMENTED, BASIC]
   hp: 70
   retreatCost: 1
   moves:
@@ -6062,7 +6062,7 @@ cards:
   number: SM227
   types: [L]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [NOT_IMPLEMENTED, BASIC]
   hp: 60
   retreatCost: 1
   moves:
@@ -6088,7 +6088,7 @@ cards:
   number: SM228
   types: [P]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [NOT_IMPLEMENTED, BASIC]
   hp: 120
   retreatCost: 3
   moves:
@@ -6175,7 +6175,7 @@ cards:
   number: SM232
   types: [L]
   superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
+  subTypes: [NOT_IMPLEMENTED, BASIC, POKEMON_GX]
   hp: 160
   retreatCost: 1
   moves:
@@ -6238,7 +6238,7 @@ cards:
   number: SM234
   types: [L]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [NOT_IMPLEMENTED, BASIC]
   hp: 60
   retreatCost: 1
   moves:
@@ -6263,7 +6263,7 @@ cards:
   number: SM235
   types: [C]
   superType: POKEMON
-  subTypes: [BASIC]
+  subTypes: [NOT_IMPLEMENTED, BASIC]
   hp: 60
   retreatCost: 1
   moves:

--- a/src/main/resources/cards/410-sun_moon_promos.yaml
+++ b/src/main/resources/cards/410-sun_moon_promos.yaml
@@ -255,249 +255,6 @@ cards:
     value: x2
   rarity: Promo
   artist: Mizue
-- id: 410-SM100
-  pioId: smp-SM100
-  enumId: LUCARIO_GX_SM100
-  name: Lucario-GX
-  nationalPokedexNumber: 448
-  number: SM100
-  types: [F]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  evolvesFrom: Riolu
-  hp: 210
-  retreatCost: 2
-  moves:
-  - cost: [F]
-    name: Aura Strike
-    damage: 30+
-    text: If this Pokémon evolved from Riolu during this turn, this attack does 90
-      more damage.
-  - cost: [F, F, C]
-    name: Cyclone Kick
-    damage: '130'
-  - cost: [C, C]
-    name: Cantankerous Beatdown-GX
-    damage: 30x
-    text: This attack does 30 damage for each damage counter on this Pokémon. (You
-      can't use more than 1 GX attack in a game.)
-  weaknesses:
-  - type: P
-    value: x2
-  rarity: Promo
-  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
-  artist: 5ban Graphics
-- id: 410-SM101
-  pioId: smp-SM101
-  enumId: DAWN_WINGS_NECROZMA_GX_SM101
-  name: Dawn Wings Necrozma-GX
-  nationalPokedexNumber: 800
-  number: SM101
-  types: [P]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  hp: 180
-  retreatCost: 2
-  abilities:
-  - type: Ability
-    name: Invasion
-    text: Once during your turn (before your attack), if this Pokémon is on your Bench,
-      you may switch it with your Active Pokémon.
-  moves:
-  - cost: [P, P, P]
-    name: Dark Flash
-    damage: '120'
-    text: This attack's damage isn't affected by Resistance.
-  - cost: [P, P, P]
-    name: Moon's Eclipse-GX
-    damage: '180'
-    text: You can use this attack only if you have more Prize cards remaining than
-      your opponent. Prevent all effects of attacks, including damage, done to this
-      Pokémon during your opponent's next turn. (You can't use more than 1 GX attack
-      in a game.)
-  weaknesses:
-  - type: D
-    value: x2
-  resistances:
-  - type: F
-    value: '-20'
-  rarity: Promo
-  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
-  artist: 5ban Graphics
-- id: 410-SM102
-  pioId: smp-SM102
-  enumId: DUSK_MANE_NECROZMA_GX_SM102
-  name: Dusk Mane Necrozma-GX
-  nationalPokedexNumber: 800
-  number: SM102
-  types: [M]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  hp: 190
-  retreatCost: 3
-  moves:
-  - cost: [C, C, C]
-    name: Claw Slash
-    damage: '60'
-  - cost: [M, M, M, C]
-    name: Meteor Tempest
-    damage: '220'
-    text: Discard 3 Energy from this Pokémon.
-  - cost: [M, M, M]
-    name: Sun's Eclipse-GX
-    damage: '250'
-    text: You can use this attack only if you have more Prize cards remaining than
-      your opponent. (You can't use more than 1 GX attack in a game.)
-  weaknesses:
-  - type: R
-    value: x2
-  resistances:
-  - type: P
-    value: '-20'
-  rarity: Promo
-  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
-  artist: 5ban Graphics
-- id: 410-SM105
-  pioId: smp-SM105
-  enumId: LYCANROC_SM105
-  name: Lycanroc
-  nationalPokedexNumber: 745
-  number: SM105
-  types: [F]
-  superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1]
-  evolvesFrom: Rockruff
-  hp: 120
-  retreatCost: 2
-  moves:
-  - cost: [C, C]
-    name: Bite
-    damage: '30'
-  - cost: [F, F, C]
-    name: Stone Edge
-    damage: 90+
-    text: Flip a coin. If heads, this attack does 30 more damage.
-  weaknesses:
-  - type: G
-    value: x2
-  rarity: Promo
-  artist: Shin Nagasawa
-- id: 410-SM106
-  pioId: smp-SM106
-  enumId: DAWN_WINGS_NECROZMA_SM106
-  name: Dawn Wings Necrozma
-  nationalPokedexNumber: 800
-  number: SM106
-  types: [P]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 130
-  retreatCost: 2
-  moves:
-  - cost: [P]
-    name: Gulf Stream
-    damage: 20+
-    text: If you have exactly 6 Prize cards remaining, this attack does 20 more damage
-      for each damage counter on this Pokémon.
-  - cost: [P, P, P]
-    name: Sword of Dawn
-    damage: '130'
-    text: Discard 2 Energy from this Pokémon.
-  weaknesses:
-  - type: D
-    value: x2
-  resistances:
-  - type: F
-    value: '-20'
-  rarity: Promo
-  artist: Shin Nagasawa
-- id: 410-SM107
-  pioId: smp-SM107
-  enumId: DUSK_MANE_NECROZMA_SM107
-  name: Dusk Mane Necrozma
-  nationalPokedexNumber: 800
-  number: SM107
-  types: [M]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 130
-  retreatCost: 2
-  moves:
-  - cost: [M]
-    name: Dusk Shot
-    text: This attack does 60 damage to 1 of your opponent's Pokémon-GX or Pokémon-EX.
-      This damage isn't affected by Weakness or Resistance.
-  - cost: [M, M, C]
-    name: Rusty Claws
-    damage: 100+
-    text: If your opponent has exactly 1 Prize card remaining, this attack does 100
-      more damage.
-  weaknesses:
-  - type: R
-    value: x2
-  resistances:
-  - type: P
-    value: '-20'
-  rarity: Promo
-  artist: Shin Nagasawa
-- id: 410-SM108
-  pioId: smp-SM108
-  enumId: ASH_S_PIKACHU_SM108
-  name: Ash's Pikachu
-  nationalPokedexNumber: 25
-  number: SM108
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC]
-  evolvesTo: [Raichu]
-  hp: 70
-  retreatCost: 1
-  moves:
-  - cost: [C]
-    name: I Choose You!
-    text: Search your deck for a Pokémon, reveal it, and put it into your hand. Then,
-      shuffle your deck.
-  - cost: [L, L, L]
-    name: Thunderbolt
-    damage: '100'
-    text: Discard all Energy from this Pokémon.
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: 2017 Pikachu Project
-- id: 410-SM109
-  pioId: smp-SM109
-  enumId: ASH_S_PIKACHU_SM109
-  name: Ash's Pikachu
-  nationalPokedexNumber: 25
-  number: SM109
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC]
-  evolvesTo: [Raichu]
-  hp: 70
-  retreatCost: 1
-  moves:
-  - cost: [C]
-    name: Agility
-    text: Flip a coin. If heads, prevent all effects of attacks, including damage,
-      done to this Pokémon during your opponent's next turn.
-  - cost: [L, L, C]
-    name: Thunder
-    damage: '80'
-    text: Flip a coin. If tails, this Pokémon does 20 damage to itself.
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: 2017 Pikachu Project
 - id: 410-SM11
   pioId: smp-SM11
   enumId: BRUXISH_SM11
@@ -524,275 +281,6 @@ cards:
     value: x2
   rarity: Promo
   artist: Mizue
-- id: 410-SM110
-  pioId: smp-SM110
-  enumId: ASH_S_PIKACHU_SM110
-  name: Ash's Pikachu
-  nationalPokedexNumber: 25
-  number: SM110
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC]
-  evolvesTo: [Raichu]
-  hp: 70
-  retreatCost: 1
-  moves:
-  - cost: [C]
-    name: Iron Tail
-    damage: 20x
-    text: Flip a coin until you get tails. This attack does 20 damage for each heads.
-  - cost: [L, L, C]
-    name: Thunder
-    damage: '80'
-    text: Flip a coin. If tails, this Pokémon does 20 damage to itself.
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: 2017 Pikachu Project
-- id: 410-SM111
-  pioId: smp-SM111
-  enumId: ASH_S_PIKACHU_SM111
-  name: Ash's Pikachu
-  nationalPokedexNumber: 25
-  number: SM111
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC]
-  evolvesTo: [Raichu]
-  hp: 70
-  retreatCost: 1
-  moves:
-  - cost: [C]
-    name: Quick Attack
-    damage: 10+
-    text: Flip a coin. If heads, this attack does 10 more damage.
-  - cost: [L, C, C]
-    name: Volt Tackle
-    damage: '60'
-    text: This Pokémon does 10 damage to itself.
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: 2017 Pikachu Project
-- id: 410-SM112
-  pioId: smp-SM112
-  enumId: ASH_S_PIKACHU_SM112
-  name: Ash's Pikachu
-  nationalPokedexNumber: 25
-  number: SM112
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC]
-  evolvesTo: [Raichu]
-  hp: 70
-  retreatCost: 1
-  moves:
-  - cost: [C]
-    name: Quick Attack
-    damage: 10+
-    text: Flip a coin. If heads, this attack does 10 more damage.
-  - cost: [L, C, C]
-    name: Electro Ball
-    damage: '50'
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: 2017 Pikachu Project
-- id: 410-SM113
-  pioId: smp-SM113
-  enumId: ASH_S_PIKACHU_SM113
-  name: Ash's Pikachu
-  nationalPokedexNumber: 25
-  number: SM113
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC]
-  evolvesTo: [Raichu]
-  hp: 70
-  retreatCost: 1
-  moves:
-  - cost: [C]
-    name: Iron Tail
-    damage: 20x
-    text: Flip a coin until you get tails. This attack does 20 damage for each heads.
-  - cost: [L, C, C]
-    name: Electro Ball
-    damage: '50'
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: 2017 Pikachu Project
-- id: 410-SM114
-  pioId: smp-SM114
-  enumId: ASH_S_PIKACHU_SM114
-  name: Ash's Pikachu
-  nationalPokedexNumber: 25
-  number: SM114
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC]
-  evolvesTo: [Raichu]
-  hp: 70
-  retreatCost: 1
-  moves:
-  - cost: [C]
-    name: Iron Tail
-    damage: 20x
-    text: Flip a coin until you get tails. This attack does 20 damage for each heads.
-  - cost: [L, L, L]
-    name: Thunderbolt
-    damage: '100'
-    text: Discard all Energy from this Pokémon.
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: 2017 Pikachu Project
-- id: 410-SM115
-  pioId: smp-SM115
-  enumId: PHEROMOSA_SM115
-  name: Pheromosa
-  nationalPokedexNumber: 795
-  number: SM115
-  types: [G]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 110
-  retreatCost: 0
-  moves:
-  - cost: [C]
-    name: High Jump Kick
-    damage: '20'
-  - cost: [G, G, C]
-    name: White Ray
-    damage: 90+
-    text: If you have only 1 Prize card remaining, this attack does 90 more damage.
-  weaknesses:
-  - type: R
-    value: x2
-  rarity: Promo
-  artist: You Iribi
-- id: 410-SM116
-  pioId: smp-SM116
-  enumId: XURKITREE_SM116
-  name: Xurkitree
-  nationalPokedexNumber: 796
-  number: SM116
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 120
-  retreatCost: 1
-  moves:
-  - cost: [L]
-    name: Dazzle Blast
-    damage: '20'
-    text: Your opponent's Active Pokémon is now Confused.
-  - cost: [L, L, C]
-    name: Cablegram
-    damage: '100'
-    text: If you have exactly 3 Prize cards remaining, your opponent's Active Pokémon
-      is now Paralyzed.
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: TOKIYA
-- id: 410-SM117
-  pioId: smp-SM117
-  enumId: MALAMAR_SM117
-  name: Malamar
-  nationalPokedexNumber: 687
-  number: SM117
-  types: [P]
-  superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1]
-  evolvesFrom: Inkay
-  hp: 90
-  retreatCost: 2
-  abilities:
-  - type: Ability
-    name: Psychic Recharge
-    text: Once during your turn (before your attack), you may attach a [P] Energy
-      card from your discard pile to 1 of your Benched Pokémon.
-  moves:
-  - cost: [P, P, C]
-    name: Psychic Sphere
-    damage: '60'
-  weaknesses:
-  - type: P
-    value: x2
-  rarity: Promo
-  artist: Shin Nagasawa
-- id: 410-SM118
-  pioId: smp-SM118
-  enumId: LYCANROC_SM118
-  name: Lycanroc
-  nationalPokedexNumber: 745
-  number: SM118
-  types: [F]
-  superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1]
-  evolvesFrom: Rockruff
-  hp: 120
-  retreatCost: 2
-  moves:
-  - cost: [F, C]
-    name: Dangerous Rogue
-    damage: 20+
-    text: This attack does 20 more damage for each of your opponent's Benched Pokémon.
-  - cost: [F, F, C]
-    name: Accelerock
-    damage: '100'
-  weaknesses:
-  - type: G
-    value: x2
-  rarity: Promo
-  artist: sui
-- id: 410-SM119
-  pioId: smp-SM119
-  enumId: EXEGGCUTE_SM119
-  name: Exeggcute
-  nationalPokedexNumber: 102
-  number: SM119
-  types: [G]
-  superType: POKEMON
-  subTypes: [BASIC]
-  evolvesTo: [Exeggutor]
-  hp: 50
-  retreatCost: 1
-  moves:
-  - cost: [C, C]
-    name: Psy Bolt
-    damage: '10'
-    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
-  weaknesses:
-  - type: R
-    value: x2
-  rarity: Promo
-  artist: OOYAMA
 - id: 410-SM12
   pioId: smp-SM12
   enumId: PASSIMIAN_SM12
@@ -818,258 +306,6 @@ cards:
     value: x2
   rarity: Promo
   artist: Naoki Saito
-- id: 410-SM120
-  pioId: smp-SM120
-  enumId: ROCKRUFF_SM120
-  name: Rockruff
-  nationalPokedexNumber: 744
-  number: SM120
-  types: [F]
-  superType: POKEMON
-  subTypes: [BASIC]
-  evolvesTo: [Lycanroc]
-  hp: 50
-  retreatCost: 1
-  moves:
-  - cost: [C, C]
-    name: Bite
-    damage: '30'
-  weaknesses:
-  - type: G
-    value: x2
-  rarity: Promo
-  artist: Hideki Ishikawa
-- id: 410-SM121
-  pioId: smp-SM121
-  enumId: RAIKOU_GX_SM121
-  name: Raikou-GX
-  nationalPokedexNumber: 243
-  number: SM121
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  hp: 170
-  retreatCost: 1
-  moves:
-  - cost: [C, C]
-    name: Dig Claws
-    damage: '30'
-  - cost: [L, L, C, C]
-    name: Thunder
-    damage: '150'
-    text: Flip a coin. If tails, this Pokémon does 50 damage to itself.
-  - cost: [L, L, L, L]
-    name: Thunderous Rain-GX
-    text: This attack does 100 damage to each of your opponent's Pokémon that has
-      any Energy attached to it. (Don't apply Weakness and Resistance for Benched
-      Pokémon.) (You can't use more than 1 GX attack in a game.)
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
-  artist: 5ban Graphics
-- id: 410-SM122
-  pioId: smp-SM122
-  enumId: ZYGARDE_GX_SM122
-  name: Zygarde-GX
-  number: SM122
-  types: [F]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  hp: 180
-  retreatCost: 2
-  moves:
-  - cost: [C]
-    name: Vibration
-    damage: '20'
-  - cost: [F, C, C]
-    name: Cell Storm
-    damage: '80'
-    text: Heal 30 damage from this Pokémon.
-  - cost: [F, F, C, C]
-    name: Liberation-GX
-    damage: 120x
-    text: Your opponent reveals their hand. This attack does 120 damage for each Energy
-      card you find there. (You can't use more than 1 GX attack in a game.)
-  weaknesses:
-  - type: G
-    value: x2
-  rarity: Promo
-  artist: 5ban Graphics
-- id: 410-SM123
-  pioId: smp-SM123
-  enumId: DAWN_WINGS_NECROZMA_SM123
-  name: Dawn Wings Necrozma
-  nationalPokedexNumber: 800
-  number: SM123
-  types: [P]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 130
-  retreatCost: 2
-  moves:
-  - cost: [P]
-    name: Gulf Stream
-    damage: 20+
-    text: If you have exactly 6 Prize cards remaining, this attack does 20 more damage
-      for each damage counter on this Pokémon.
-  - cost: [P, P, P]
-    name: Sword of Dawn
-    damage: '130'
-    text: Discard 2 Energy from this Pokémon.
-  weaknesses:
-  - type: D
-    value: x2
-  resistances:
-  - type: F
-    value: '-20'
-  rarity: Promo
-  artist: nagimiso
-- id: 410-SM124
-  pioId: smp-SM124
-  enumId: DUSK_MANE_NECROZMA_SM124
-  name: Dusk Mane Necrozma
-  nationalPokedexNumber: 800
-  number: SM124
-  types: [M]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 130
-  retreatCost: 2
-  moves:
-  - cost: [M]
-    name: Dusk Shot
-    text: This attack does 60 damage to 1 of your opponent's Pokémon-GX or Pokémon-EX.
-      This damage isn't affected by Weakness or Resistance.
-  - cost: [M, M, C]
-    name: Rusty Claws
-    damage: 100+
-    text: If your opponent has exactly 1 Prize card remaining, this attack does 100
-      more damage.
-  weaknesses:
-  - type: R
-    value: x2
-  resistances:
-  - type: P
-    value: '-20'
-  rarity: Promo
-  artist: nagimiso
-- id: 410-SM125
-  pioId: smp-SM125
-  enumId: NAGANADEL_GX_SM125
-  name: Naganadel-GX
-  number: SM125
-  types: [P]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  evolvesFrom: Poipole
-  hp: 210
-  retreatCost: 1
-  moves:
-  - cost: [C]
-    name: Beast Raid
-    damage: 20x
-    text: This attack does 20 damage for each of your Ultra Beasts in play.
-  - cost: [P, C, C]
-    name: Jet Needle
-    damage: '110'
-    text: This attack's damage isn't affected by Weakness or Resistance.
-  - cost: [C, C, C]
-    name: Stinger-GX
-    text: Both players shuffle their Prize cards into their decks. Then, each player
-      puts the top 3 cards of their deck face down as their Prize cards. (You can't
-      use more than 1 GX attack in a game.)
-  weaknesses:
-  - type: P
-    value: x2
-  rarity: Promo
-  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
-  artist: 5ban Graphics
-- id: 410-SM127
-  pioId: smp-SM127
-  enumId: ALOLAN_SANDSLASH_SM127
-  name: Alolan Sandslash
-  nationalPokedexNumber: 28
-  number: SM127
-  types: [M]
-  superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1]
-  evolvesFrom: Alolan Sandshrew
-  hp: 120
-  retreatCost: 2
-  moves:
-  - cost: [M]
-    name: Metal Claw
-    damage: '20'
-  - cost: [M, M, C]
-    name: Tumbling Attack
-    damage: 80+
-    text: Flip a coin. If heads, this attack does 40 more damage.
-  weaknesses:
-  - type: R
-    value: x2
-  resistances:
-  - type: P
-    value: '-20'
-  rarity: Promo
-  artist: kirisAki
-- id: 410-SM128
-  pioId: smp-SM128
-  enumId: ALOLAN_NINETALES_SM128
-  name: Alolan Ninetales
-  nationalPokedexNumber: 38
-  number: SM128
-  types: [Y]
-  superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1]
-  evolvesFrom: Alolan Vulpix
-  hp: 110
-  retreatCost: 1
-  moves:
-  - cost: [C, C]
-    name: Smash Kick
-    damage: '30'
-  - cost: [Y, Y, C]
-    name: Spiral Drain
-    damage: '80'
-    text: Heal 30 damage from this Pokémon.
-  weaknesses:
-  - type: M
-    value: x2
-  resistances:
-  - type: D
-    value: '-20'
-  rarity: Promo
-  artist: kirisAki
-- id: 410-SM129
-  pioId: smp-SM129
-  enumId: KYOGRE_SM129
-  name: Kyogre
-  nationalPokedexNumber: 382
-  number: SM129
-  types: [W]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 130
-  retreatCost: 4
-  moves:
-  - cost: [W, C]
-    name: Dual Splash
-    text: This attack does 30 damage to 2 of your opponent's Pokémon. (Don't apply
-      Weakness and Resistance for Benched Pokémon.)
-  - cost: [W, W, C]
-    name: Grand Wave
-    damage: '120'
-    text: This Pokémon can't use Grand Wave during your next turn.
-  weaknesses:
-  - type: G
-    value: x2
-  rarity: Promo
-  artist: Anesaki Dynamic
 - id: 410-SM13
   pioId: smp-SM13
   enumId: ORANGURU_SM13
@@ -1097,204 +333,6 @@ cards:
     value: x2
   rarity: Promo
   artist: Mitsuhiro Arita
-- id: 410-SM130
-  pioId: smp-SM130
-  enumId: MANECTRIC_SM130
-  name: Manectric
-  nationalPokedexNumber: 310
-  number: SM130
-  types: [L]
-  superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1]
-  evolvesFrom: Electrike
-  hp: 110
-  retreatCost: 0
-  abilities:
-  - type: Ability
-    name: Electric Start
-    text: If you go second, and if this Pokémon is in your hand when you are setting
-      up to play, you may put it face down as your Active Pokémon or on your Bench.
-  moves:
-  - cost: [L]
-    name: Double Charge
-    damage: '40'
-    text: You may attach up to 2 basic Energy cards from your hand to 1 of your Benched
-      Pokémon.
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: Ryota Murayama
-- id: 410-SM131
-  pioId: smp-SM131
-  enumId: CELESTEELA_SM131
-  name: Celesteela
-  nationalPokedexNumber: 797
-  number: SM131
-  types: [M]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 140
-  retreatCost: 4
-  moves:
-  - cost: [M, C, C, C, C]
-    name: Moon Raker
-    damage: '160'
-    text: If the total of both players' remaining Prize cards is exactly 6, this attack
-      can be used for Metal.
-  weaknesses:
-  - type: L
-    value: x2
-  resistances:
-  - type: F
-    value: '-20'
-  rarity: Promo
-  artist: Masakazu Fukuda
-- id: 410-SM132
-  pioId: smp-SM132
-  enumId: DELCATTY_SM132
-  name: Delcatty
-  nationalPokedexNumber: 301
-  number: SM132
-  types: [C]
-  superType: POKEMON
-  subTypes: [EVOLUTION, STAGE1]
-  evolvesFrom: Skitty
-  hp: 90
-  retreatCost: 1
-  abilities:
-  - type: Ability
-    name: Search for Friends
-    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
-      your turn, you may put 2 Supporter cards from your discard pile into your hand.
-  moves:
-  - cost: [C, C]
-    name: Cat Kick
-    damage: '40'
-  weaknesses:
-  - type: F
-    value: x2
-  rarity: Promo
-  artist: '0313'
-- id: 410-SM133
-  pioId: smp-SM133
-  enumId: THUNDURUS_GX_SM133
-  name: Thundurus-GX
-  nationalPokedexNumber: 641
-  number: SM133
-  types: [L]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  hp: 180
-  retreatCost: 2
-  moves:
-  - cost: [L]
-    name: Charge
-    text: Search your deck for a [L] Energy card and attach it to this Pokémon. Then,
-      shuffle your deck.
-  - cost: [L, L, L]
-    name: Electric Ball
-    damage: '140'
-  - cost: [L, L, L]
-    name: Thundering Hurricane-GX
-    damage: 100x
-    text: Flip 4 coins. This attack does 100 damage for each heads. (You can't use
-      more than 1 GX attack in a game.)
-  weaknesses:
-  - type: F
-    value: x2
-  resistances:
-  - type: M
-    value: '-20'
-  rarity: Promo
-  artist: 5ban Graphics
-- id: 410-SM134
-  pioId: smp-SM134
-  enumId: TORNADUS_GX_SM134
-  name: Tornadus-GX
-  nationalPokedexNumber: 640
-  number: SM134
-  types: [C]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  hp: 180
-  retreatCost: 2
-  moves:
-  - cost: [C, C]
-    name: Gust
-    damage: '50'
-  - cost: [C, C, C]
-    name: Wild Fury
-    damage: 90+
-    text: Flip a coin until you get tails. This attack does 30 more damage for each
-      heads.
-  - cost: [C, C, C]
-    name: Destructive Cyclone-GX
-    damage: '130'
-    text: Discard all Energy from your opponent's Active Pokémon. (You can't use more
-      than 1 GX attack in a game.)
-  weaknesses:
-  - type: L
-    value: x2
-  resistances:
-  - type: F
-    value: '-20'
-  rarity: Promo
-  artist: 5ban Graphics
-- id: 410-SM135
-  pioId: smp-SM135
-  enumId: LATIAS_SM135
-  name: Latias
-  nationalPokedexNumber: 380
-  number: SM135
-  types: [N]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 110
-  retreatCost: 1
-  moves:
-  - cost: [C, C]
-    name: Hypnoblast
-    damage: '30'
-    text: Your opponent's Active Pokémon is now Asleep.
-  - cost: [R, P, C]
-    name: Mist Ball
-    damage: '110'
-    text: Flip a coin. If tails, discard a [R] Energy and a [P] Energy from this Pokémon.
-  weaknesses:
-  - type: Y
-    value: x2
-  rarity: Promo
-  artist: Kouki Saitou
-- id: 410-SM136
-  pioId: smp-SM136
-  enumId: LATIOS_SM136
-  name: Latios
-  nationalPokedexNumber: 381
-  number: SM136
-  types: [N]
-  superType: POKEMON
-  subTypes: [BASIC]
-  hp: 120
-  retreatCost: 2
-  moves:
-  - cost: [C]
-    name: Energy Extract
-    damage: '20'
-    text: Search your deck for a basic Energy card and attach it to this Pokémon.
-      Then, shuffle your deck.
-  - cost: [W, P, C, C]
-    name: Luster Purge
-    damage: '140'
-    text: Flip a coin. If tails, discard all Energy attached to this Pokémon.
-  weaknesses:
-  - type: Y
-    value: x2
-  rarity: Promo
-  artist: Kouki Saitou
 - id: 410-SM14
   pioId: smp-SM14
   enumId: LYCANROC_GX_SM14
@@ -1326,85 +364,6 @@ cards:
   rarity: Promo
   text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
   artist: 5ban Graphics
-- id: 410-SM146
-  pioId: smp-SM146
-  enumId: LEAFEON_GX_SM146
-  name: Leafeon-GX
-  nationalPokedexNumber: 470
-  number: SM146
-  types: [G]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  evolvesFrom: Eevee
-  hp: 200
-  retreatCost: 2
-  abilities:
-  - type: Ability
-    name: Breath of the Leaves
-    text: If this Pokémon is your Active Pokémon, once during your turn (before your
-      attack), you may heal 50 damage from 1 of your Pokémon that has any Energy attached
-      to it.
-  moves:
-  - cost: [G, C, C]
-    name: Solar Beam
-    damage: '110'
-  - cost: [G]
-    name: Grand Bloom-GX
-    text: For each of your Benched Basic Pokémon, search your deck for a card that
-      evolves from that Pokémon and put it onto that Pokémon to evolve it. Then, shuffle
-      your deck. (You can't use more than 1 GX attack in a game.)
-  weaknesses:
-  - type: R
-    value: x2
-  rarity: Promo
-  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
-  artist: 5ban Graphics
-- id: 410-SM147
-  pioId: smp-SM147
-  enumId: GLACEON_GX_SM147
-  name: Glaceon-GX
-  nationalPokedexNumber: 471
-  number: SM147
-  types: [W]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  evolvesFrom: Eevee
-  hp: 200
-  retreatCost: 2
-  abilities:
-  - type: Ability
-    name: Freezing Gaze
-    text: As long as this Pokémon is your Active Pokémon, your opponent's Pokémon-GX
-      and Pokémon-EX in play, in their hand, and in their discard pile have no Abilities,
-      except for Freezing Gaze.
-  moves:
-  - cost: [W, C, C]
-    name: Frost Bullet
-    damage: '90'
-    text: This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't
-      apply Weakness and Resistance for Benched Pokémon.)
-  - cost: [W, C, C]
-    name: Polar Spear-GX
-    damage: 50x
-    text: This attack does 50 damage for each damage counter on your opponent's Active
-      Pokémon. (You can't use more than 1 GX attack in a game.)
-  weaknesses:
-  - type: M
-    value: x2
-  rarity: Promo
-  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
-  artist: 5ban Graphics
-- id: 410-SM148
-  pioId: smp-SM148
-  enumId: CHAMPIONS_FESTIVAL_SM148
-  name: Champions Festival
-  number: SM148
-  superType: TRAINER
-  subTypes: [STADIUM]
-  rarity: Promo
-  text: ['Once during each player''s turn, if that player has 6 Pokémon in play, they
-      may heal 10 damage from each of their Pokémon.']
-  artist: Naoki Saito
 - id: 410-SM15
   pioId: smp-SM15
   enumId: ZYGARDE_SM15
@@ -1428,69 +387,6 @@ cards:
     value: x2
   rarity: Promo
   artist: kawayoo
-- id: 410-SM155
-  pioId: smp-SM155
-  enumId: KINGDRA_GX_SM155
-  name: Kingdra-GX
-  nationalPokedexNumber: 230
-  number: SM155
-  types: [W]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  evolvesFrom: Seadra
-  hp: 230
-  retreatCost: 2
-  moves:
-  - cost: [C]
-    name: Hydro Pump
-    damage: 10+
-    text: This attack does 50 more damage times the amount of [W] Energy attached
-      to this Pokémon.
-  - cost: [W]
-    name: Reverse Thrust
-    damage: '30'
-    text: Switch this Pokémon with 1 of your Benched Pokémon.
-  - cost: [W]
-    name: Maelstrom-GX
-    text: This attack does 40 damage to each of your opponent's Pokémon. (Don't apply
-      Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX
-      attack in a game.)
-  weaknesses:
-  - type: G
-    value: x2
-  rarity: Promo
-  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
-  artist: 5ban Graphics
-- id: 410-SM156
-  pioId: smp-SM156
-  enumId: DRAGONITE_GX_SM156
-  name: Dragonite-GX
-  nationalPokedexNumber: 149
-  number: SM156
-  types: [N]
-  superType: POKEMON
-  subTypes: [BASIC, POKEMON_GX]
-  evolvesFrom: Dragonair
-  hp: 250
-  retreatCost: 3
-  moves:
-  - cost: [L]
-    name: Dragon Claw
-    damage: '70'
-  - cost: [W, L, C, C]
-    name: Giga Impact
-    damage: '200'
-    text: This Pokémon can't attack during your next turn.
-  - cost: [C, C, C]
-    name: Dragonporter-GX
-    text: Put 3 [N] Pokémon from your discard pile onto your Bench. (You can't use
-      more than 1 GX attack in a game.)
-  weaknesses:
-  - type: Y
-    value: x2
-  rarity: Promo
-  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
-  artist: 5ban Graphics
 - id: 410-SM16
   pioId: smp-SM16
   enumId: SOLGALEO_GX_SM16
@@ -3849,6 +2745,2569 @@ cards:
       their last turn, use it as this attack.
   rarity: Promo
   artist: Megumi Mizutani
+- id: 410-SM100
+  pioId: smp-SM100
+  enumId: LUCARIO_GX_SM100
+  name: Lucario-GX
+  nationalPokedexNumber: 448
+  number: SM100
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  evolvesFrom: Riolu
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Aura Strike
+    damage: 30+
+    text: If this Pokémon evolved from Riolu during this turn, this attack does 90
+      more damage.
+  - cost: [F, F, C]
+    name: Cyclone Kick
+    damage: '130'
+  - cost: [C, C]
+    name: Cantankerous Beatdown-GX
+    damage: 30x
+    text: This attack does 30 damage for each damage counter on this Pokémon. (You
+      can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+  artist: 5ban Graphics
+- id: 410-SM101
+  pioId: smp-SM101
+  enumId: DAWN_WINGS_NECROZMA_GX_SM101
+  name: Dawn Wings Necrozma-GX
+  nationalPokedexNumber: 800
+  number: SM101
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 180
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Invasion
+    text: Once during your turn (before your attack), if this Pokémon is on your Bench,
+      you may switch it with your Active Pokémon.
+  moves:
+  - cost: [P, P, P]
+    name: Dark Flash
+    damage: '120'
+    text: This attack's damage isn't affected by Resistance.
+  - cost: [P, P, P]
+    name: Moon's Eclipse-GX
+    damage: '180'
+    text: You can use this attack only if you have more Prize cards remaining than
+      your opponent. Prevent all effects of attacks, including damage, done to this
+      Pokémon during your opponent's next turn. (You can't use more than 1 GX attack
+      in a game.)
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+  artist: 5ban Graphics
+- id: 410-SM102
+  pioId: smp-SM102
+  enumId: DUSK_MANE_NECROZMA_GX_SM102
+  name: Dusk Mane Necrozma-GX
+  nationalPokedexNumber: 800
+  number: SM102
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 190
+  retreatCost: 3
+  moves:
+  - cost: [C, C, C]
+    name: Claw Slash
+    damage: '60'
+  - cost: [M, M, M, C]
+    name: Meteor Tempest
+    damage: '220'
+    text: Discard 3 Energy from this Pokémon.
+  - cost: [M, M, M]
+    name: Sun's Eclipse-GX
+    damage: '250'
+    text: You can use this attack only if you have more Prize cards remaining than
+      your opponent. (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+  artist: 5ban Graphics
+- id: 410-SM105
+  pioId: smp-SM105
+  enumId: LYCANROC_SM105
+  name: Lycanroc
+  nationalPokedexNumber: 745
+  number: SM105
+  types: [F]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Rockruff
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Bite
+    damage: '30'
+  - cost: [F, F, C]
+    name: Stone Edge
+    damage: 90+
+    text: Flip a coin. If heads, this attack does 30 more damage.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Shin Nagasawa
+- id: 410-SM106
+  pioId: smp-SM106
+  enumId: DAWN_WINGS_NECROZMA_SM106
+  name: Dawn Wings Necrozma
+  nationalPokedexNumber: 800
+  number: SM106
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Gulf Stream
+    damage: 20+
+    text: If you have exactly 6 Prize cards remaining, this attack does 20 more damage
+      for each damage counter on this Pokémon.
+  - cost: [P, P, P]
+    name: Sword of Dawn
+    damage: '130'
+    text: Discard 2 Energy from this Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+  artist: Shin Nagasawa
+- id: 410-SM107
+  pioId: smp-SM107
+  enumId: DUSK_MANE_NECROZMA_SM107
+  name: Dusk Mane Necrozma
+  nationalPokedexNumber: 800
+  number: SM107
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [M]
+    name: Dusk Shot
+    text: This attack does 60 damage to 1 of your opponent's Pokémon-GX or Pokémon-EX.
+      This damage isn't affected by Weakness or Resistance.
+  - cost: [M, M, C]
+    name: Rusty Claws
+    damage: 100+
+    text: If your opponent has exactly 1 Prize card remaining, this attack does 100
+      more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+  artist: Shin Nagasawa
+- id: 410-SM108
+  pioId: smp-SM108
+  enumId: ASH_S_PIKACHU_SM108
+  name: Ash's Pikachu
+  nationalPokedexNumber: 25
+  number: SM108
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: I Choose You!
+    text: Search your deck for a Pokémon, reveal it, and put it into your hand. Then,
+      shuffle your deck.
+  - cost: [L, L, L]
+    name: Thunderbolt
+    damage: '100'
+    text: Discard all Energy from this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: 2017 Pikachu Project
+- id: 410-SM109
+  pioId: smp-SM109
+  enumId: ASH_S_PIKACHU_SM109
+  name: Ash's Pikachu
+  nationalPokedexNumber: 25
+  number: SM109
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Agility
+    text: Flip a coin. If heads, prevent all effects of attacks, including damage,
+      done to this Pokémon during your opponent's next turn.
+  - cost: [L, L, C]
+    name: Thunder
+    damage: '80'
+    text: Flip a coin. If tails, this Pokémon does 20 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: 2017 Pikachu Project
+- id: 410-SM110
+  pioId: smp-SM110
+  enumId: ASH_S_PIKACHU_SM110
+  name: Ash's Pikachu
+  nationalPokedexNumber: 25
+  number: SM110
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Iron Tail
+    damage: 20x
+    text: Flip a coin until you get tails. This attack does 20 damage for each heads.
+  - cost: [L, L, C]
+    name: Thunder
+    damage: '80'
+    text: Flip a coin. If tails, this Pokémon does 20 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: 2017 Pikachu Project
+- id: 410-SM111
+  pioId: smp-SM111
+  enumId: ASH_S_PIKACHU_SM111
+  name: Ash's Pikachu
+  nationalPokedexNumber: 25
+  number: SM111
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Quick Attack
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 more damage.
+  - cost: [L, C, C]
+    name: Volt Tackle
+    damage: '60'
+    text: This Pokémon does 10 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: 2017 Pikachu Project
+- id: 410-SM112
+  pioId: smp-SM112
+  enumId: ASH_S_PIKACHU_SM112
+  name: Ash's Pikachu
+  nationalPokedexNumber: 25
+  number: SM112
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Quick Attack
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 more damage.
+  - cost: [L, C, C]
+    name: Electro Ball
+    damage: '50'
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: 2017 Pikachu Project
+- id: 410-SM113
+  pioId: smp-SM113
+  enumId: ASH_S_PIKACHU_SM113
+  name: Ash's Pikachu
+  nationalPokedexNumber: 25
+  number: SM113
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Iron Tail
+    damage: 20x
+    text: Flip a coin until you get tails. This attack does 20 damage for each heads.
+  - cost: [L, C, C]
+    name: Electro Ball
+    damage: '50'
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: 2017 Pikachu Project
+- id: 410-SM114
+  pioId: smp-SM114
+  enumId: ASH_S_PIKACHU_SM114
+  name: Ash's Pikachu
+  nationalPokedexNumber: 25
+  number: SM114
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Raichu]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Iron Tail
+    damage: 20x
+    text: Flip a coin until you get tails. This attack does 20 damage for each heads.
+  - cost: [L, L, L]
+    name: Thunderbolt
+    damage: '100'
+    text: Discard all Energy from this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: 2017 Pikachu Project
+- id: 410-SM115
+  pioId: smp-SM115
+  enumId: PHEROMOSA_SM115
+  name: Pheromosa
+  nationalPokedexNumber: 795
+  number: SM115
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 0
+  moves:
+  - cost: [C]
+    name: High Jump Kick
+    damage: '20'
+  - cost: [G, G, C]
+    name: White Ray
+    damage: 90+
+    text: If you have only 1 Prize card remaining, this attack does 90 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: You Iribi
+- id: 410-SM116
+  pioId: smp-SM116
+  enumId: XURKITREE_SM116
+  name: Xurkitree
+  nationalPokedexNumber: 796
+  number: SM116
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Dazzle Blast
+    damage: '20'
+    text: Your opponent's Active Pokémon is now Confused.
+  - cost: [L, L, C]
+    name: Cablegram
+    damage: '100'
+    text: If you have exactly 3 Prize cards remaining, your opponent's Active Pokémon
+      is now Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: TOKIYA
+- id: 410-SM117
+  pioId: smp-SM117
+  enumId: MALAMAR_SM117
+  name: Malamar
+  nationalPokedexNumber: 687
+  number: SM117
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Inkay
+  hp: 90
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Psychic Recharge
+    text: Once during your turn (before your attack), you may attach a [P] Energy
+      card from your discard pile to 1 of your Benched Pokémon.
+  moves:
+  - cost: [P, P, C]
+    name: Psychic Sphere
+    damage: '60'
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  artist: Shin Nagasawa
+- id: 410-SM118
+  pioId: smp-SM118
+  enumId: LYCANROC_SM118
+  name: Lycanroc
+  nationalPokedexNumber: 745
+  number: SM118
+  types: [F]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Rockruff
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [F, C]
+    name: Dangerous Rogue
+    damage: 20+
+    text: This attack does 20 more damage for each of your opponent's Benched Pokémon.
+  - cost: [F, F, C]
+    name: Accelerock
+    damage: '100'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: sui
+- id: 410-SM119
+  pioId: smp-SM119
+  enumId: EXEGGCUTE_SM119
+  name: Exeggcute
+  nationalPokedexNumber: 102
+  number: SM119
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Exeggutor]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Psy Bolt
+    damage: '10'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  artist: OOYAMA
+- id: 410-SM120
+  pioId: smp-SM120
+  enumId: ROCKRUFF_SM120
+  name: Rockruff
+  nationalPokedexNumber: 744
+  number: SM120
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  evolvesTo: [Lycanroc]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Bite
+    damage: '30'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Hideki Ishikawa
+- id: 410-SM121
+  pioId: smp-SM121
+  enumId: RAIKOU_GX_SM121
+  name: Raikou-GX
+  nationalPokedexNumber: 243
+  number: SM121
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 170
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Dig Claws
+    damage: '30'
+  - cost: [L, L, C, C]
+    name: Thunder
+    damage: '150'
+    text: Flip a coin. If tails, this Pokémon does 50 damage to itself.
+  - cost: [L, L, L, L]
+    name: Thunderous Rain-GX
+    text: This attack does 100 damage to each of your opponent's Pokémon that has
+      any Energy attached to it. (Don't apply Weakness and Resistance for Benched
+      Pokémon.) (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+  artist: 5ban Graphics
+- id: 410-SM122
+  pioId: smp-SM122
+  enumId: ZYGARDE_GX_SM122
+  name: Zygarde-GX
+  number: SM122
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 180
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Vibration
+    damage: '20'
+  - cost: [F, C, C]
+    name: Cell Storm
+    damage: '80'
+    text: Heal 30 damage from this Pokémon.
+  - cost: [F, F, C, C]
+    name: Liberation-GX
+    damage: 120x
+    text: Your opponent reveals their hand. This attack does 120 damage for each Energy
+      card you find there. (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: 5ban Graphics
+- id: 410-SM123
+  pioId: smp-SM123
+  enumId: DAWN_WINGS_NECROZMA_SM123
+  name: Dawn Wings Necrozma
+  nationalPokedexNumber: 800
+  number: SM123
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [P]
+    name: Gulf Stream
+    damage: 20+
+    text: If you have exactly 6 Prize cards remaining, this attack does 20 more damage
+      for each damage counter on this Pokémon.
+  - cost: [P, P, P]
+    name: Sword of Dawn
+    damage: '130'
+    text: Discard 2 Energy from this Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+  artist: nagimiso
+- id: 410-SM124
+  pioId: smp-SM124
+  enumId: DUSK_MANE_NECROZMA_SM124
+  name: Dusk Mane Necrozma
+  nationalPokedexNumber: 800
+  number: SM124
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [M]
+    name: Dusk Shot
+    text: This attack does 60 damage to 1 of your opponent's Pokémon-GX or Pokémon-EX.
+      This damage isn't affected by Weakness or Resistance.
+  - cost: [M, M, C]
+    name: Rusty Claws
+    damage: 100+
+    text: If your opponent has exactly 1 Prize card remaining, this attack does 100
+      more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+  artist: nagimiso
+- id: 410-SM125
+  pioId: smp-SM125
+  enumId: NAGANADEL_GX_SM125
+  name: Naganadel-GX
+  number: SM125
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  evolvesFrom: Poipole
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Beast Raid
+    damage: 20x
+    text: This attack does 20 damage for each of your Ultra Beasts in play.
+  - cost: [P, C, C]
+    name: Jet Needle
+    damage: '110'
+    text: This attack's damage isn't affected by Weakness or Resistance.
+  - cost: [C, C, C]
+    name: Stinger-GX
+    text: Both players shuffle their Prize cards into their decks. Then, each player
+      puts the top 3 cards of their deck face down as their Prize cards. (You can't
+      use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+  artist: 5ban Graphics
+- id: 410-SM127
+  pioId: smp-SM127
+  enumId: ALOLAN_SANDSLASH_SM127
+  name: Alolan Sandslash
+  nationalPokedexNumber: 28
+  number: SM127
+  types: [M]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Alolan Sandshrew
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [M]
+    name: Metal Claw
+    damage: '20'
+  - cost: [M, M, C]
+    name: Tumbling Attack
+    damage: 80+
+    text: Flip a coin. If heads, this attack does 40 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+  artist: kirisAki
+- id: 410-SM128
+  pioId: smp-SM128
+  enumId: ALOLAN_NINETALES_SM128
+  name: Alolan Ninetales
+  nationalPokedexNumber: 38
+  number: SM128
+  types: [Y]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Alolan Vulpix
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Smash Kick
+    damage: '30'
+  - cost: [Y, Y, C]
+    name: Spiral Drain
+    damage: '80'
+    text: Heal 30 damage from this Pokémon.
+  weaknesses:
+  - type: M
+    value: x2
+  resistances:
+  - type: D
+    value: '-20'
+  rarity: Promo
+  artist: kirisAki
+- id: 410-SM129
+  pioId: smp-SM129
+  enumId: KYOGRE_SM129
+  name: Kyogre
+  nationalPokedexNumber: 382
+  number: SM129
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 4
+  moves:
+  - cost: [W, C]
+    name: Dual Splash
+    text: This attack does 30 damage to 2 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, W, C]
+    name: Grand Wave
+    damage: '120'
+    text: This Pokémon can't use Grand Wave during your next turn.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  artist: Anesaki Dynamic
+- id: 410-SM130
+  pioId: smp-SM130
+  enumId: MANECTRIC_SM130
+  name: Manectric
+  nationalPokedexNumber: 310
+  number: SM130
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Electrike
+  hp: 110
+  retreatCost: 0
+  abilities:
+  - type: Ability
+    name: Electric Start
+    text: If you go second, and if this Pokémon is in your hand when you are setting
+      up to play, you may put it face down as your Active Pokémon or on your Bench.
+  moves:
+  - cost: [L]
+    name: Double Charge
+    damage: '40'
+    text: You may attach up to 2 basic Energy cards from your hand to 1 of your Benched
+      Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: Ryota Murayama
+- id: 410-SM131
+  pioId: smp-SM131
+  enumId: CELESTEELA_SM131
+  name: Celesteela
+  nationalPokedexNumber: 797
+  number: SM131
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [M, C, C, C, C]
+    name: Moon Raker
+    damage: '160'
+    text: If the total of both players' remaining Prize cards is exactly 6, this attack
+      can be used for Metal.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+  artist: Masakazu Fukuda
+- id: 410-SM132
+  pioId: smp-SM132
+  enumId: DELCATTY_SM132
+  name: Delcatty
+  nationalPokedexNumber: 301
+  number: SM132
+  types: [C]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Skitty
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Search for Friends
+    text: When you play this Pokémon from your hand to evolve 1 of your Pokémon during
+      your turn, you may put 2 Supporter cards from your discard pile into your hand.
+  moves:
+  - cost: [C, C]
+    name: Cat Kick
+    damage: '40'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  artist: '0313'
+- id: 410-SM133
+  pioId: smp-SM133
+  enumId: THUNDURUS_GX_SM133
+  name: Thundurus-GX
+  nationalPokedexNumber: 641
+  number: SM133
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 180
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Charge
+    text: Search your deck for a [L] Energy card and attach it to this Pokémon. Then,
+      shuffle your deck.
+  - cost: [L, L, L]
+    name: Electric Ball
+    damage: '140'
+  - cost: [L, L, L]
+    name: Thundering Hurricane-GX
+    damage: 100x
+    text: Flip 4 coins. This attack does 100 damage for each heads. (You can't use
+      more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+  artist: 5ban Graphics
+- id: 410-SM134
+  pioId: smp-SM134
+  enumId: TORNADUS_GX_SM134
+  name: Tornadus-GX
+  nationalPokedexNumber: 640
+  number: SM134
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 180
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Gust
+    damage: '50'
+  - cost: [C, C, C]
+    name: Wild Fury
+    damage: 90+
+    text: Flip a coin until you get tails. This attack does 30 more damage for each
+      heads.
+  - cost: [C, C, C]
+    name: Destructive Cyclone-GX
+    damage: '130'
+    text: Discard all Energy from your opponent's Active Pokémon. (You can't use more
+      than 1 GX attack in a game.)
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+  artist: 5ban Graphics
+- id: 410-SM135
+  pioId: smp-SM135
+  enumId: LATIAS_SM135
+  name: Latias
+  nationalPokedexNumber: 380
+  number: SM135
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Hypnoblast
+    damage: '30'
+    text: Your opponent's Active Pokémon is now Asleep.
+  - cost: [R, P, C]
+    name: Mist Ball
+    damage: '110'
+    text: Flip a coin. If tails, discard a [R] Energy and a [P] Energy from this Pokémon.
+  weaknesses:
+  - type: Y
+    value: x2
+  rarity: Promo
+  artist: Kouki Saitou
+- id: 410-SM136
+  pioId: smp-SM136
+  enumId: LATIOS_SM136
+  name: Latios
+  nationalPokedexNumber: 381
+  number: SM136
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Energy Extract
+    damage: '20'
+    text: Search your deck for a basic Energy card and attach it to this Pokémon.
+      Then, shuffle your deck.
+  - cost: [W, P, C, C]
+    name: Luster Purge
+    damage: '140'
+    text: Flip a coin. If tails, discard all Energy attached to this Pokémon.
+  weaknesses:
+  - type: Y
+    value: x2
+  rarity: Promo
+  artist: Kouki Saitou
+- id: 410-SM137
+  pioId: smp-SM137
+  enumId: RESHIRAM_GX_SM137
+  name: Reshiram-GX
+  number: SM137
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 180
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Flame Charge
+    text: Search your deck for up to 2 [R] Energy cards and attach them to this Pokémon.
+      Then, shuffle your deck.
+  - cost: [R, R, R, C]
+    name: Scorching Column
+    damage: '110'
+    text: Your opponent's Active Pokémon is now Burned.
+  - cost: [R, R, R, C]
+    name: Vermilion GX
+    damage: '180'
+    text: You may attach up to 5 [R] Energy cards from your hand to your Pokémon in
+      any way you like. (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM138
+  pioId: smp-SM138
+  enumId: ZEKROM_GX_SM138
+  name: Zekrom-GX
+  number: SM138
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 180
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Bullet Uppercut
+    damage: 10+
+    text: If your opponent's Active Pokémon is a Pokémon-GX or a Pokémon-EX, this
+      attack does 60 more damage. This attack's damage isn't affected by Weakness.
+  - cost: [L, L, L, C]
+    name: Swift Bolt Strike
+    damage: 80+
+    text: Flip 2 coins. This attack does 60 more damage for each heads.
+  - cost: [L, L, L, C]
+    name: Rampage Bolt GX
+    damage: '200'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon. (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM139
+  pioId: smp-SM139
+  enumId: SALAMENCE_GX_SM139
+  name: Salamence-GX
+  number: SM139
+  types: [N]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE2]
+  evolvesFrom: Shelgon
+  hp: 250
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Dragon Lift
+    text: Your Pokémon in play have no Retreat Cost, except Pokémon-GX and Pokémon-EX.
+  moves:
+  - cost: [R, W, C, C]
+    name: Bright Flame
+    damage: '200'
+    text: Discard 2 Energy from this Pokémon.
+  - cost: [R, C, C]
+    name: Flame Jet GX
+    text: This attack does 120 damage to 1 of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX
+      attack in a game.)
+  weaknesses:
+  - type: Y
+    value: x2
+  rarity: Promo
+- id: 410-SM140
+  pioId: smp-SM140
+  enumId: SALAMENCE_SM140
+  name: Salamence
+  number: SM140
+  types: [N]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Shelgon
+  hp: 150
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Dragon Wind
+    text: If this Pokémon is your Active Pokémon, once during your turn (before your
+      attack), you may switch 1 of your opponent’s Benched Pokémon with their Active
+      Pokémon.
+  moves:
+  - cost: [R, W, C, C]
+    name: Dragon Claw
+    damage: '100'
+  weaknesses:
+  - type: Y
+    value: x2
+  rarity: Promo
+- id: 410-SM141
+  pioId: smp-SM141
+  enumId: WHITE_KYUREM_GX_SM141
+  name: White Kyurem-GX
+  number: SM141
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 190
+  retreatCost: 3
+  moves:
+  - cost: [R]
+    name: Shred
+    damage: '40'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  - cost: [R, W, C]
+    name: Raging Blade
+    damage: 80+
+    text: If this Pokémon has any damage counters on it, this attack does 80 more
+      damage.
+  - cost: [R, R, W, C]
+    name: Dragon Nova GX
+    damage: '200'
+    text: Your opponent's Active Pokémon is now Burned and Paralyzed. (You can't use
+      more than 1 GX attack in a game.)
+  weaknesses:
+  - type: Y
+    value: x2
+  rarity: Promo
+- id: 410-SM142
+  pioId: smp-SM142
+  enumId: KYUREM_SM142
+  name: Kyurem
+  number: SM142
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Outrage
+    damage: 20+
+    text: This attack does 10 more damage for each damage counter on this Pokémon.
+  - cost: [W, W, C]
+    name: Frost Spear
+    damage: '100'
+    text: This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  weaknesses:
+  - type: Y
+    value: x2
+  rarity: Promo
+- id: 410-SM143
+  pioId: smp-SM143
+  enumId: MOLTRES_SM143
+  name: Moltres
+  number: SM143
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [R, C, C]
+    name: Wing Attack
+    damage: '70'
+  - cost: [R, C, C, C]
+    name: Sky Attack
+    damage: '150'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+- id: 410-SM144
+  pioId: smp-SM144
+  enumId: ARTICUNO_SM144
+  name: Articuno
+  number: SM144
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Gust
+    damage: '30'
+  - cost: [W, W, C]
+    name: Sheer Cold
+    damage: '100'
+    text: Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's
+      next turn.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+- id: 410-SM145
+  pioId: smp-SM145
+  enumId: ZAPDOS_SM145
+  name: Zapdos
+  number: SM145
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Thunder Shock
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [C, C, C, C]
+    name: Drill Peck
+    damage: '120'
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+- id: 410-SM146
+  pioId: smp-SM146
+  enumId: LEAFEON_GX_SM146
+  name: Leafeon-GX
+  nationalPokedexNumber: 470
+  number: SM146
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  evolvesFrom: Eevee
+  hp: 200
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Breath of the Leaves
+    text: If this Pokémon is your Active Pokémon, once during your turn (before your
+      attack), you may heal 50 damage from 1 of your Pokémon that has any Energy attached
+      to it.
+  moves:
+  - cost: [G, C, C]
+    name: Solar Beam
+    damage: '110'
+  - cost: [G]
+    name: Grand Bloom-GX
+    text: For each of your Benched Basic Pokémon, search your deck for a card that
+      evolves from that Pokémon and put it onto that Pokémon to evolve it. Then, shuffle
+      your deck. (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+  artist: 5ban Graphics
+- id: 410-SM147
+  pioId: smp-SM147
+  enumId: GLACEON_GX_SM147
+  name: Glaceon-GX
+  nationalPokedexNumber: 471
+  number: SM147
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  evolvesFrom: Eevee
+  hp: 200
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Freezing Gaze
+    text: As long as this Pokémon is your Active Pokémon, your opponent's Pokémon-GX
+      and Pokémon-EX in play, in their hand, and in their discard pile have no Abilities,
+      except for Freezing Gaze.
+  moves:
+  - cost: [W, C, C]
+    name: Frost Bullet
+    damage: '90'
+    text: This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, C, C]
+    name: Polar Spear-GX
+    damage: 50x
+    text: This attack does 50 damage for each damage counter on your opponent's Active
+      Pokémon. (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+  artist: 5ban Graphics
+- id: 410-SM148
+  pioId: smp-SM148
+  enumId: CHAMPIONS_FESTIVAL_SM148
+  name: Champions Festival
+  number: SM148
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Promo
+  text: ['Once during each player''s turn, if that player has 6 Pokémon in play, they
+      may heal 10 damage from each of their Pokémon.']
+  artist: Naoki Saito
+- id: 410-SM149
+  pioId: smp-SM149
+  enumId: SUICUNE_SM149
+  name: Suicune
+  number: SM149
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Frozen Flow
+    text: Once during your turn (before your attack), if this Pokémon is your Active
+      Pokémon, you may have your opponent switch their Active Pokémon with 1 of their
+      Benched Pokémon.
+  moves:
+  - cost: [W, C, C]
+    name: Aurora Gain
+    damage: '70'
+    text: Heal 30 damage from this Pokémon.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 410-SM150
+  pioId: smp-SM150
+  enumId: RAIKOU_SM150
+  name: Raikou
+  number: SM150
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [L, C]
+    name: Lost Voltage
+    damage: 30+
+    text: If you have any [L] Energy cards in the Lost Zone, this attack does 90 more
+      damage.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM151
+  pioId: smp-SM151
+  enumId: GIRATINA_SM151
+  name: Giratina
+  number: SM151
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Distortion Door
+    text: Once during your turn (before your attack), if this Pokémon is in your discard
+      pile, you may put it onto your Bench. If you do, put 1 damage counter on 2 of
+      your opponent’s Benched Pokémon.
+  moves:
+  - cost: [P, P, C]
+    name: Shadow Impact
+    damage: '130'
+    text: Put 4 damage counters on 1 of your Pokémon.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+- id: 410-SM152
+  pioId: smp-SM152
+  enumId: TAPU_LELE_SM152
+  name: Tapu Lele
+  number: SM152
+  types: [Y]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Charmed Charm
+    text: Whenever you attach a Pokémon Tool card that has "Fairy Charm" in its name
+      from your hand to this Pokémon during your turn, you may leave your opponent’s
+      Active Pokémon Confused.
+  moves:
+  - cost: [Y, C, C]
+    name: Magical Shot
+    damage: '70'
+  weaknesses:
+  - type: M
+    value: x2
+  resistances:
+  - type: D
+    value: '-20'
+  rarity: Promo
+- id: 410-SM153
+  pioId: smp-SM153
+  enumId: ROWLET_SM153
+  name: Rowlet
+  number: SM153
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [G, C]
+    name: Leaf Blade
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 30 more damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 410-SM154
+  pioId: smp-SM154
+  enumId: SALANDIT_SM154
+  name: Salandit
+  number: SM154
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Smog
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned.
+  - cost: [R, C]
+    name: Ember
+    damage: '30'
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM155
+  pioId: smp-SM155
+  enumId: KINGDRA_GX_SM155
+  name: Kingdra-GX
+  nationalPokedexNumber: 230
+  number: SM155
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  evolvesFrom: Seadra
+  hp: 230
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Hydro Pump
+    damage: 10+
+    text: This attack does 50 more damage times the amount of [W] Energy attached
+      to this Pokémon.
+  - cost: [W]
+    name: Reverse Thrust
+    damage: '30'
+    text: Switch this Pokémon with 1 of your Benched Pokémon.
+  - cost: [W]
+    name: Maelstrom-GX
+    text: This attack does 40 damage to each of your opponent's Pokémon. (Don't apply
+      Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX
+      attack in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+  artist: 5ban Graphics
+- id: 410-SM156
+  pioId: smp-SM156
+  enumId: DRAGONITE_GX_SM156
+  name: Dragonite-GX
+  nationalPokedexNumber: 149
+  number: SM156
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  evolvesFrom: Dragonair
+  hp: 250
+  retreatCost: 3
+  moves:
+  - cost: [L]
+    name: Dragon Claw
+    damage: '70'
+  - cost: [W, L, C, C]
+    name: Giga Impact
+    damage: '200'
+    text: This Pokémon can't attack during your next turn.
+  - cost: [C, C, C]
+    name: Dragonporter-GX
+    text: Put 3 [N] Pokémon from your discard pile onto your Bench. (You can't use
+      more than 1 GX attack in a game.)
+  weaknesses:
+  - type: Y
+    value: x2
+  rarity: Promo
+  text: ['When your Pokémon-GX is Knocked Out, your opponent takes 2 Prize cards.']
+  artist: 5ban Graphics
+- id: 410-SM157
+  pioId: smp-SM157
+  enumId: PIKACHU_SM157
+  name: Pikachu
+  number: SM157
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Pika Shield
+    text: This Pokémon can't be Paralyzed.
+  moves:
+  - cost: [L]
+    name: Static Shock
+    damage: '10'
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM158
+  pioId: smp-SM158
+  enumId: CHARIZARD_SM158
+  name: Charizard
+  number: SM158
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Charmeleon
+  hp: 150
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Roaring Resolve
+    text: Once during your turn (before your attack), you may put 2 damage counters
+      on this Pokémon. If you do, search your deck for up to 2 [R] Energy cards and
+      attach them to this Pokémon. Then, shuffle your deck.
+  moves:
+  - cost: [R, R]
+    name: Continuous Blaze Ball
+    damage: 30+
+    text: Discard all [R] Energy from this Pokémon. This attack does 50 more damage
+      for each card you discarded in this way.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM159
+  pioId: smp-SM159
+  enumId: ZAPDOS_SM159
+  name: Zapdos
+  number: SM159
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Thunderous Assault
+    damage: 10+
+    text: If this Pokémon was on the Bench and became your Active Pokémon this turn,
+      this attack does 70 more damage. This attack’s damage isn't affected by Weakness.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+- id: 410-SM160
+  pioId: smp-SM160
+  enumId: NIDOQUEEN_SM160
+  name: Nidoqueen
+  number: SM160
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Nidorina
+  hp: 160
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Queen's Call
+    text: Once during your turn (before your attack), you may search your deck for
+      a Pokémon that isn’t a Pokémon-GX or Pokémon-EX, reveal it, and put it into
+      your hand. Then, shuffle your deck.
+  moves:
+  - cost: [C, C, C]
+    name: Power Lariat
+    damage: 10+
+    text: This attack does 50 more damage for each Evolution Pokémon on your Bench.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+- id: 410-SM161
+  pioId: smp-SM161
+  enumId: JIRACHI_SM161
+  name: Jirachi
+  number: SM161
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Stellar Wish
+    text: Once during your turn (before your attack), if this Pokémon is your Active
+      Pokémon, you may look at the top 5 cards of your deck, reveal a Trainer card
+      you find there, and put it into your hand. Then, shuffle the other cards back
+      into your deck, and this Pokémon is now Asleep.
+  moves:
+  - cost: [M, C]
+    name: Slap
+    damage: '30'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+- id: 410-SM162
+  pioId: smp-SM162
+  enumId: PIKACHU_SM162
+  name: Pikachu
+  number: SM162
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Nuzzle
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [L, C]
+    name: Thunder Jolt
+    damage: '30'
+    text: This Pokémon does 10 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM163
+  pioId: smp-SM163
+  enumId: MIMIKYU_SM163
+  name: Mimikyu
+  number: SM163
+  types: [Y]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [Y]
+    name: Mimic
+    text: Shuffle your hand into your deck. Then, draw a card for each card in your
+      opponent's hand.
+  - cost: [Y, C]
+    name: Play Rough
+    damage: 20+
+    text: Flip a coin. If heads, this attack does 20 more damage.
+  rarity: Promo
+- id: 410-SM164
+  pioId: smp-SM164
+  enumId: DEOXYS_SM164
+  name: Deoxys
+  number: SM164
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Power Suction
+    text: Once during your turn (before your attack), you may move an Energy from
+      1 of your Pokémon to 1 of your Deoxys.
+  moves:
+  - cost: [P, P, C]
+    name: Psycho Boost
+    damage: '100'
+    text: During your next turn, this Pokémon's Psycho Boost attack's base damage
+      is 50.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+- id: 410-SM165
+  pioId: smp-SM165
+  enumId: ULTRA_NECROZMA_SM165
+  name: Ultra Necrozma
+  number: SM165
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 3
+  moves:
+  - cost: [M, M, P, P]
+    name: Shining Burst
+    damage: 100+
+    text: If the total of both players' remaining Prize cards is 6 or less, discard
+      all Energy from this Pokémon, and this attack does 100 more damage.
+  weaknesses:
+  - type: Y
+    value: x2
+  rarity: Promo
+- id: 410-SM166
+  pioId: smp-SM166
+  enumId: MAGIKARP_WAILORD_GX_SM166
+  name: Magikarp & Wailord-GX
+  number: SM166
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 300
+  retreatCost: 4
+  moves:
+  - cost: [W, W, W, W, W]
+    name: Super Splash
+    damage: '180'
+  - cost: [W]
+    name: Towering Splash GX
+    damage: '10'
+    text: If this Pokémon has at least 7 extra [W] Energy attached to it (in addition
+      to this attack's cost), this attack does 100 damage to each of your opponent's
+      Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+      (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 410-SM167
+  pioId: smp-SM167
+  enumId: CELEBI_VENUSAUR_GX_SM167
+  name: Celebi & Venusaur-GX
+  number: SM167
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 270
+  retreatCost: 4
+  moves:
+  - cost: [G, C, C]
+    name: Pollen Hazard
+    damage: '50'
+    text: Your opponent's Active Pokémon is now Burned, Confused, and Poisoned.
+  - cost: [G, G, C, C]
+    name: Solar Beam
+    damage: '150'
+  - cost: [G, G, C, C]
+    name: Evergreen GX
+    damage: '180'
+    text: Heal all damage from this Pokémon. If this Pokémon has at least 1 extra
+      [G] Energy attached to it (in addition to this attack's cost), shuffle all cards
+      from your discard pile into your deck. (You can't use more than 1 GX attack
+      in a game.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Ultra Rare
+- id: 410-SM168
+  pioId: smp-SM168
+  enumId: PIKACHU_ZEKROM_GX_SM168
+  name: Pikachu & Zekrom-GX
+  number: SM168
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 240
+  retreatCost: 3
+  moves:
+  - cost: [L, L, L]
+    name: Full Blitz
+    damage: '150'
+    text: Search your deck for up to 3 [L] Energy cards and attach them to 1 of your
+      Pokémon. Then, shuffle your deck.
+  - cost: [L, L, L]
+    name: Tag Bolt GX
+    damage: '200'
+    text: If this Pokémon has at least 3 extra [L] Energy attached to it (in addition
+      to this attack's cost), this attack does 170 damage to 1 of your opponent's
+      Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
+      (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Ultra Rare
+- id: 410-SM169
+  pioId: smp-SM169
+  enumId: EEVEE_SNORLAX_GX_SM169
+  name: Eevee & Snorlax-GX
+  number: SM169
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 270
+  retreatCost: 4
+  moves:
+  - cost: [C]
+    name: Cheer Up
+    text: Attach an Energy card from your hand to 1 of your Pokémon.
+  - cost: [C, C, C, C]
+    name: Dump Truck Press
+    damage: 120+
+    text: If your opponent's Active Pokémon is an Evolution Pokémon, this attack does
+      120 more damage.
+  - cost: [C, C, C, C]
+    name: Megaton Friends GX
+    damage: '210'
+    text: If this Pokémon has at least 1 extra Energy attached to it (in addition
+      to this attack's cost), draw cards until you have 10 cards in your hand. (You
+      can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Ultra Rare
+- id: 410-SM170
+  pioId: smp-SM170
+  enumId: DETECTIVE_PIKACHU_SM170
+  name: Detective Pikachu
+  number: SM170
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Scout
+    text: Your opponent reveals their hand.
+  - cost: [C, C, C]
+    name: Surprise Attack
+    damage: '80'
+    text: Flip a coin. If tails, this attack does nothing.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM171
+  pioId: smp-SM171
+  enumId: FLAREON_GX_SM171
+  name: Flareon-GX
+  number: SM171
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
+  evolvesFrom: Eevee
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Heat Stage
+    damage: '30'
+    text: You may attach up to 3 [R] Energy cards from your hand to your Pokémon in
+      any way you like.
+  - cost: [R, R, C]
+    name: Bright Flame
+    damage: '190'
+    text: Discard 2 [R] Energy from this Pokémon.
+  - cost: [R]
+    name: Power Burner GX
+    damage: 20x
+    text: This attack does 20 damage for each [R] Energy card in your discard pile.
+      (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM172
+  pioId: smp-SM172
+  enumId: VAPOREON_GX_SM172
+  name: Vaporeon-GX
+  number: SM172
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
+  evolvesFrom: Eevee
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Hydrating Drops
+    text: Once during your turn (before your attack), you may heal 30 damage from
+      your Active [W] Pokémon.
+  moves:
+  - cost: [C, C, C]
+    name: Hydro Pump
+    damage: 40+
+    text: This attack does 30 more damage times the amount of [W] Energy attached
+      to this Pokémon.
+  - cost: [W]
+    name: Cure Shower GX
+    text: Heal all damage from all of your [W] Pokémon. (You can't use more than 1
+      GX attack in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 410-SM173
+  pioId: smp-SM173
+  enumId: JOLTEON_GX_SM173
+  name: Jolteon-GX
+  number: SM173
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
+  evolvesFrom: Eevee
+  hp: 200
+  retreatCost: 0
+  moves:
+  - cost: [L]
+    name: Electrobullet
+    damage: '30'
+    text: This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't
+      apply Weakness and Resistance for Benched Pokémon.)
+  - cost: [L, C]
+    name: Head Bolt
+    damage: '110'
+  - cost: [L, C]
+    name: Swift Run GX
+    damage: '110'
+    text: Prevent all effects of attacks, including damage, done to this Pokémon during
+      your opponent's next turn. (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM174
+  pioId: smp-SM174
+  enumId: EEVEE_GX_SM174
+  name: Eevee-GX
+  number: SM174
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 160
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Ascension DNA
+    text: Once during your turn (before your attack), if you have a Pokémon in your
+      hand that evolves from Eevee, you may put that card onto this Pokémon to evolve
+      it. Before evolving, heal all damage from this Pokémon. You can't use this Ability
+      during your first turn or the turn this Pokémon was put into play.
+  moves:
+  - cost: [C, C, C]
+    name: Boost Dash
+    damage: '100'
+  - cost: [C]
+    name: Joy Maker GX
+    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+      1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 410-SM175
+  pioId: smp-SM175
+  enumId: EEVEE_GX_SM175
+  name: Eevee-GX
+  number: SM175
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 160
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Ascension DNA
+    text: Once during your turn (before your attack), if you have a Pokémon in your
+      hand that evolves from Eevee, you may put that card onto this Pokémon to evolve
+      it. Before evolving, heal all damage from this Pokémon. You can't use this Ability
+      during your first turn or the turn this Pokémon was put into play.
+  moves:
+  - cost: [C, C, C]
+    name: Boost Dash
+    damage: '100'
+  - cost: [C]
+    name: Joy Maker GX
+    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+      1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  copyOf: 410-SM174
+  copyType: Reprint
+- id: 410-SM176
+  pioId: smp-SM176
+  enumId: EEVEE_GX_SM176
+  name: Eevee-GX
+  number: SM176
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 160
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Ascension DNA
+    text: Once during your turn (before your attack), if you have a Pokémon in your
+      hand that evolves from Eevee, you may put that card onto this Pokémon to evolve
+      it. Before evolving, heal all damage from this Pokémon. You can't use this Ability
+      during your first turn or the turn this Pokémon was put into play.
+  moves:
+  - cost: [C, C, C]
+    name: Boost Dash
+    damage: '100'
+  - cost: [C]
+    name: Joy Maker GX
+    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+      1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  copyOf: 410-SM174
+  copyType: Reprint
+- id: 410-SM177
+  pioId: smp-SM177
+  enumId: MELTAN_SM177
+  name: Meltan
+  number: SM177
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [M]
+    name: Multiply
+    text: Search your deck for Meltan and put it onto your Bench. Then, shuffle your
+      deck.
+  - cost: [C, C]
+    name: Beam
+    damage: '30'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+- id: 410-SM178
+  pioId: smp-SM178
+  enumId: MELMETAL_GX_SM178
+  name: Melmetal-GX
+  number: SM178
+  types: [M]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
+  evolvesFrom: Meltan
+  hp: 220
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Hard Coat
+    text: This Pokémon takes 30 less damage from attacks (after applying Weakness
+      and Resistance).
+  moves:
+  - cost: [C, C, C, C]
+    name: Metal Blast
+    damage: 110+
+    text: This attack does 20 more damage times the amount of [M] Energy attached
+      to this Pokémon.
+  - cost: [M]
+    name: Iron Force GX
+    text: Attach any number of [M] Energy cards from your discard pile to this Pokémon.
+      (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+- id: 410-SM179
+  pioId: smp-SM179
+  enumId: VOLCANION_SM179
+  name: Volcanion
+  number: SM179
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Flare Starter
+    text: Search your deck for a [R] Energy card and attach it to 1 of your Pokémon.
+      If you go second and it's your first turn, instead search for up to 3 [R] Energy
+      cards and attach them to your Pokémon in any way you like. Then, shuffle your
+      deck.
+  - cost: [R, R]
+    name: High-Heat Blast
+    damage: 50+
+    text: If you have at least 4 [R] Energy in play, this attack does 60 more damage.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM180
+  pioId: smp-SM180
+  enumId: STAKATAKA_SM180
+  name: Stakataka
+  number: SM180
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Wall of Stone
+    text: If your opponent has 3 or fewer Prize cards remaining, this Pokémon's maximum
+      HP is 200.
+  moves:
+  - cost: [F, F, C]
+    name: Top Down
+    damage: '110'
+    text: Flip a coin until you get tails. For each heads, discard the top card of
+      your opponent's deck.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 410-SM181
+  pioId: smp-SM181
+  enumId: MELMETAL_SM181
+  name: Melmetal
+  number: SM181
+  types: [M]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Meltan
+  hp: 150
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Metal Eater
+    text: Once during your turn (before your attack), you may discard a [M] Pokémon
+      from your hand. If you do, heal 100 damage from this Pokémon.
+  moves:
+  - cost: [M, C, C, C]
+    name: Heavy Impact
+    damage: '130'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+- id: 410-SM182
+  pioId: smp-SM182
+  enumId: PERSIAN_SM182
+  name: Persian
+  number: SM182
+  types: [C]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Meowth
+  hp: 100
+  retreatCost: 0
+  abilities:
+  - type: Ability
+    name: Gathering of Cats
+    text: Ignore all Energy in the attack costs of each of your Pokémon in play that
+      has the Caturday attack.
+  moves:
+  - cost: [C, C, C]
+    name: Claw Slash
+    damage: '90'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 410-SM183
+  pioId: smp-SM183
+  enumId: PIKACHU_SM183
+  name: Pikachu
+  number: SM183
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [L, C]
+    name: Thunder Jolt
+    damage: '40'
+    text: This Pokémon does 20 damage to itself.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM184
+  pioId: smp-SM184
+  enumId: EEVEE_SM184
+  name: Eevee
+  number: SM184
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Find a Friend
+    text: Flip a coin. If heads, search your deck for a Pokémon, reveal it, and put
+      it into your hand. Then, shuffle your deck.
+  - cost: [C, C]
+    name: Smash Kick
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 410-SM185
+  pioId: smp-SM185
+  enumId: TYPHLOSION_SM185
+  name: Typhlosion
+  number: SM185
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Quilava
+  hp: 150
+  retreatCost: 2
+  moves:
+  - cost: [R]
+    name: Exploder
+    text: Search your deck for up to 3 [R] Energy cards and attach them to your Pokémon
+      in any way you like. Then, shuffle your deck.
+  - cost: [R, R, C]
+    name: Bursting Inferno
+    damage: '100'
+    text: Your opponent’s Active Pokémon is now Burned.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM186
+  pioId: smp-SM186
+  enumId: FLAREON_SM186
+  name: Flareon
+  number: SM186
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Eevee
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Bite
+    damage: '20'
+  - cost: [R, R, C]
+    name: Fire Spin
+    damage: '130'
+    text: Discard 2 [R] Energy from this Pokémon.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM187
+  pioId: smp-SM187
+  enumId: ALOLAN_MAROWAK_GX_SM187
+  name: Alolan Marowak-GX
+  number: SM187
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
+  evolvesFrom: Cubone
+  hp: 200
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Cursed Body
+    text: If this Pokémon is your Active Pokémon and is damaged by an opponent's attack
+      (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Confused.
+  moves:
+  - cost: [R, C, C]
+    name: Fiery Bone
+    damage: '90'
+    text: Your opponent's Active Pokémon is now Burned.
+  - cost: []
+    name: Lost Boomerang GX
+    text: This attack does 50 damage to 2 of your opponent's Pokémon. This damage
+      isn't affected by Weakness or Resistance. If a Pokémon is Knocked Out by this
+      damage, put that Pokémon and all cards attached to it in the Lost Zone instead
+      of the discard pile. (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM188
+  pioId: smp-SM188
+  enumId: KANGASKHAN_GX_SM188
+  name: Kangaskhan-GX
+  number: SM188
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 180
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Split Spiral Punch
+    damage: '20'
+    text: Your opponent’s Active Pokémon is now Confused.
+  - cost: [C, C, C]
+    name: Enraged Strike
+    damage: 80+
+    text: If your opponent's Active Pokémon is Confused, this attack does 80 more
+      damage.
+  - cost: [C, C, C]
+    name: Familial Combo GX
+    damage: '150'
+    text: Draw 5 cards. (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 410-SM189
+  pioId: smp-SM189
+  enumId: BLASTOISE_GX_SM189
+  name: Blastoise-GX
+  number: SM189
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE2]
+  evolvesFrom: Wartortle
+  hp: 240
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Solid Shell
+    text: This Pokémon takes 30 less damage from attacks (after applying Weakness
+      and Resistance).
+  moves:
+  - cost: [W, W]
+    name: Rocket Splash
+    damage: 60x
+    text: Shuffle any amount of [W] Energy from your Pokémon into your deck. This
+      attack does 60 damage for each card you shuffled into your deck in this way.
+  - cost: [W]
+    name: Giant Geyser GX
+    text: Attach any number of [W] Energy cards from your hand to your Pokémon in
+      any way you like. (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 410-SM190
+  pioId: smp-SM190
+  enumId: DETECTIVE_PIKACHU_SM190
+  name: Detective Pikachu
+  number: SM190
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Coffee Break
+    text: Heal 30 damage from this Pokémon.
+  - cost: [C, C]
+    name: Corkscrew Punch
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM191
+  pioId: smp-SM191
+  enumId: MEWTWO_MEW_GX_SM191
+  name: Mewtwo & Mew-GX
+  number: SM191
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 270
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Perfection
+    text: This Pokémon can use the attacks of any Pokémon-GX or Pokémon-EX on your
+      Bench or in your discard pile. (You still need the necessary Energy to use each
+      attack.)
+  moves:
+  - cost: [P, P, C]
+    name: Miraculous Duo GX
+    damage: '200'
+    text: If this Pokémon has at least 1 extra Energy attached to it (in addition
+      to this attack’s cost), heal all damage from all of your Pokémon. (You can’t
+      use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+- id: 410-SM192
+  pioId: smp-SM192
+  enumId: LUCARIO_MELMETAL_GX_SM192
+  name: Lucario & Melmetal-GX
+  number: SM192
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 260
+  retreatCost: 3
+  moves:
+  - cost: [C, C]
+    name: Steel Fist
+    damage: '50'
+    text: Search your deck for a [M] Energy card and attach it to this Pokémon. Then,
+      shuffle your deck.
+  - cost: [M, M, C, C]
+    name: Heavy Impact
+    damage: '150'
+  - cost: [C]
+    name: Full Metal Wall GX
+    text: For the rest of this game, your [M] Pokémon take 30 less damage from your
+      opponent's attacks (after applying Weakness and Resistance). If this Pokémon
+      has at least 1 extra Energy attached to it (in addition to this attack's cost),
+      discard all Energy from your opponent's Active Pokémon. (You can't use more
+      than 1 GX attack in a game.)
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: P
+    value: '-20'
+  rarity: Promo
+- id: 410-SM193
+  pioId: smp-SM193
+  enumId: GARCHOMP_GIRATINA_GX_SM193
+  name: Garchomp & Giratina-GX
+  number: SM193
+  types: [N]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 270
+  retreatCost: 3
+  moves:
+  - cost: [C]
+    name: Linear Attack
+    text: This attack does 40 damage to 1 of your opponent’s Pokémon. (Don’t apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [F, P, C]
+    name: Calamitous Slash
+    damage: 160+
+    text: If your opponent's Active Pokémon already has any damage counters on it,
+      this attack does 80 more damage.
+  - cost: [F, P, P]
+    name: GG End GX
+    text: Discard 1 of your opponent's Pokémon and all cards attached to it. If this
+      Pokémon has at least 3 extra [F] Energy attached to it (in addition to this
+      attack’s cost), discard 2 of your opponent's Pokémon instead. (You can’t use
+      more than 1 GX attack in a game.)
+  weaknesses:
+  - type: Y
+    value: x2
+  rarity: Promo
+- id: 410-SM194
+  pioId: smp-SM194
+  enumId: DETECTIVE_PIKACHU_SM194
+  name: Detective Pikachu
+  number: SM194
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 90
+  retreatCost: 2
+  moves:
+  - cost: [L]
+    name: Brilliant Deduction
+    text: Look at the top 4 cards of your deck and put 1 of them into your hand. Shuffle
+      the other cards back into your deck.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM195
+  pioId: smp-SM195
+  enumId: CHARIZARD_GX_SM195
+  name: Charizard-GX
+  number: SM195
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE2]
+  evolvesFrom: Charmeleon
+  hp: 250
+  retreatCost: 4
+  moves:
+  - cost: [R]
+    name: Raging Destruction
+    text: Discard the top 8 cards of your deck. If any of those cards are [R] Energy
+      cards, attach them to this Pokémon.
+  - cost: [R, R, C, C, C]
+    name: Steam Artillery
+    damage: '200'
+  - cost: [R, R, C, C, C]
+    name: Dreadful Flames GX
+    damage: '250'
+    text: Discard an Energy from each of your opponent's Pokémon. (You can't use more
+      than 1 GX attack in a game.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM196
+  pioId: smp-SM196
+  enumId: MEWTWO_GX_SM196
+  name: Mewtwo-GX
+  number: SM196
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 190
+  retreatCost: 2
+  moves:
+  - cost: [P, C]
+    name: Telekinesis
+    text: This attack does 50 damage to 1 of your opponent's Pokémon. This damage
+      isn't affected by Weakness or Resistance.
+  - cost: [P, P, C, C]
+    name: Reigning Pulse
+    damage: '120'
+    text: Your opponent’s Active Pokémon is now Confused.
+  - cost: [P, P, C, C]
+    name: Psychic Nova GX
+    damage: '180'
+    text: Prevent all damage done to this Pokémon by attacks during your opponent's
+      next turn. (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
 - id: 410-SM197
   pioId: smp-SM197
   enumId: GRENINJA_GX_SM197
@@ -3878,7 +5337,472 @@ cards:
   weaknesses:
   - type: G
     value: x2
-  rarity: Promo  
+  rarity: Promo
+- id: 410-SM198
+  pioId: smp-SM198
+  enumId: BULBASAUR_SM198
+  name: Bulbasaur
+  number: SM198
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Ram
+    damage: '10'
+  - cost: [G, G, C]
+    name: Vine Whip
+    damage: '50'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 410-SM199
+  pioId: smp-SM199
+  enumId: PSYDUCK_SM199
+  name: Psyduck
+  number: SM199
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 2
+  moves:
+  - cost: [W, C]
+    name: Scratch
+    damage: '30'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 410-SM200
+  pioId: smp-SM200
+  enumId: SNUBBULL_SM200
+  name: Snubbull
+  number: SM200
+  types: [Y]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [Y]
+    name: Bite
+    damage: '10'
+  - cost: [C, C]
+    name: Paralyzing Gaze
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  weaknesses:
+  - type: M
+    value: x2
+  resistances:
+  - type: D
+    value: '-20'
+  rarity: Promo
+- id: 410-SM201
+  pioId: smp-SM201
+  enumId: RESHIRAM_CHARIZARD_GX_SM201
+  name: Reshiram & Charizard-GX
+  number: SM201
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 270
+  retreatCost: 3
+  moves:
+  - cost: [R, C]
+    name: Outrage
+    damage: 30+
+    text: This attack does 10 more damage for each damage counter on this Pokémon.
+  - cost: [R, R, R, C]
+    name: Flare Strike
+    damage: '230'
+    text: This Pokémon can't use Flare Strike during your next turn.
+  - cost: [R, R, R]
+    name: Double Blaze GX
+    damage: 200+
+    text: If this Pokémon has at least 3 extra [R] Energy attached to it (in addition
+      to this attack's cost), this attack does 100 more damage, and this attack's
+      damage isn't affected by any effects on your opponent's Active Pokémon. (You
+      can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Ultra Rare
+- id: 410-SM202
+  pioId: smp-SM202
+  enumId: AMOONGUSS_SM202
+  name: Amoonguss
+  number: SM202
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Foongus
+  hp: 100
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Bursting Spores
+    text: Whenever you play a Pokémon that has the Spore attack from your hand during
+      your turn, you may leave your opponent's Active Pokémon Asleep and Poisoned.
+  moves:
+  - cost: [C, C]
+    name: Venoshock
+    damage: 20+
+    text: If your opponent's Active Pokémon is Poisoned, this attack does 70 more
+      damage.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 410-SM203
+  pioId: smp-SM203
+  enumId: TAPU_FINI_SM203
+  name: Tapu Fini
+  number: SM203
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Razor Fin
+    damage: '20'
+  - cost: [W, W, C]
+    name: Nature Wave
+    damage: '100'
+    text: If your opponent has any Ultra Beasts in play, this attack can be used for
+      [C].
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 410-SM204
+  pioId: smp-SM204
+  enumId: NECROZMA_SM204
+  name: Necrozma
+  number: SM204
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Barrier Attack
+    damage: '30'
+    text: During your opponent’s next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  - cost: [P, P, C]
+    name: Special Laser
+    damage: 100+
+    text: If this Pokémon has any Special Energy attached to it, this attack does
+      60 more damage.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+- id: 410-SM205
+  pioId: smp-SM205
+  enumId: TERRAKION_SM205
+  name: Terrakion
+  number: SM205
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [F, C, C]
+    name: Cavern Counter
+    damage: 50+
+    text: If all of your Benched Pokémon have at least 1 damage counter on them, this
+      attack does 150 more damage.
+  - cost: [F, F, C, C]
+    name: Boulder Crush
+    damage: '110'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 410-SM206
+  pioId: smp-SM206
+  enumId: PIKACHU_SM206
+  name: Pikachu
+  number: SM206
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [L, C, C]
+    name: Thundershock
+    damage: '40'
+    text: Flip a coin. If heads, the Defending Pokémon is now Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM207
+  pioId: smp-SM207
+  enumId: SUDOWOODO_SM207
+  name: Sudowoodo
+  number: SM207
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [F]
+    name: Low Kick
+    damage: '20'
+  - cost: [F, F]
+    name: Territorial Strike
+    damage: '80'
+    text: If you don’t have a Stadium card in play, this attack does nothing.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM208
+  pioId: smp-SM208
+  enumId: VIKAVOLT_SM208
+  name: Vikavolt
+  number: SM208
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Charjabug
+  hp: 150
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Stealthy Body
+    text: If there is any Stadium card in play, this Pokémon has no Weakness.
+  moves:
+  - cost: [L, L, L, C]
+    name: Electricannon
+    damage: 120+
+    text: You may discard all [L] Energy from this Pokémon. If you do, this attack
+      does 100 more damage.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM209
+  pioId: smp-SM209
+  enumId: STAKATAKA_SM209
+  name: Stakataka
+  number: SM209
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Wall of Stone
+    text: If your opponent has 3 or fewer Prize cards remaining, this Pokémon's maximum
+      HP is 200.
+  moves:
+  - cost: [F, F, C]
+    name: Top Down
+    damage: '110'
+    text: Flip a coin until you get tails. For each heads, discard the top card of
+      your opponent's deck.
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  copyOf: 410-SM180
+  copyType: Reprint
+- id: 410-SM210
+  pioId: smp-SM210
+  enumId: MOLTRES_ZAPDOS_ARTICUNO_GX_SM210
+  name: Moltres & Zapdos & Articuno-GX
+  number: SM210
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 300
+  retreatCost: 3
+  moves:
+  - cost: [R, L, W, C]
+    name: Trinity Burn
+    damage: '210'
+  - cost: [C]
+    name: Sky Legends GX
+    text: Shuffle this Pokémon and all cards attached to it into your deck. If this
+      Pokémon has at least 1 extra [R], [W], and [L] Energy attached to it (in addition
+      to this attack's cost), this attack does 110 damage to 3 of your opponent's
+      Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't
+      use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+- id: 410-SM211
+  pioId: smp-SM211
+  enumId: CHARIZARD_GX_SM211
+  name: Charizard-GX
+  number: SM211
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE2]
+  evolvesFrom: Charmeleon
+  hp: 250
+  retreatCost: 3
+  moves:
+  - cost: [R, R, C, C]
+    name: Flamethrower
+    damage: '140'
+  - cost: [R, R, C, C]
+    name: Flare Blitz GX
+    damage: '300'
+    text: (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM212
+  pioId: smp-SM212
+  enumId: GYARADOS_GX_SM212
+  name: Gyarados-GX
+  number: SM212
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
+  evolvesFrom: Magikarp
+  hp: 230
+  retreatCost: 3
+  moves:
+  - cost: [W, W, W, C]
+    name: Dragon Rage
+    damage: '130'
+  - cost: [W, W, W, C]
+    name: Hyper Beam GX
+    damage: '240'
+    text: (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+- id: 410-SM213
+  pioId: smp-SM213
+  enumId: RAICHU_GX_SM213
+  name: Raichu-GX
+  number: SM213
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
+  evolvesFrom: Pikachu
+  hp: 210
+  retreatCost: 1
+  moves:
+  - cost: [L, L, C]
+    name: Thunderbolt
+    damage: '120'
+  - cost: [L, L, C]
+    name: Spark Ball GX
+    damage: '200'
+    text: (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM214
+  pioId: smp-SM214
+  enumId: MEWTWO_SM214
+  name: Mewtwo
+  number: SM214
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Mind Report
+    text: When you play this Pokémon from your hand onto your Bench during your turn,
+      you may put a Supporter card from your discard pile on top of your deck.
+  moves:
+  - cost: [P, C, C]
+    name: Psyshock
+    damage: '70'
+    text: This attack's damage isn't affected by any effects on your opponent's Active
+      Pokémon.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+- id: 410-SM215
+  pioId: smp-SM215
+  enumId: MEW_SM215
+  name: Mew
+  number: SM215
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Bench Barrier
+    text: Prevent all damage done to your Benched Pokémon by your opponent's attacks.
+  moves:
+  - cost: [C]
+    name: Psypower
+    text: Put 3 damage counters on your opponent's Pokémon in any way you like.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+- id: 410-SM216
+  pioId: smp-SM216
+  enumId: PORYGON_Z_GX_SM216
+  name: Porygon-Z-GX
+  number: SM216
+  types: [C]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE2]
+  evolvesFrom: Porygon2
+  hp: 240
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Troubleshooting
+    text: Once during your turn (before your attack), you may discard a Special Energy
+      from this Pokémon. If you do, heal 80 damage from it.
+  moves:
+  - cost: [C, C, C]
+    name: Abnormal Overheating
+    damage: '160'
+    text: This Pokémon is now Burned.
+  - cost: [C]
+    name: Critical Error GX
+    text: Search your deck for up to 10 cards and discard them. Then, shuffle your
+      deck. (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
 - id: 410-SM217
   pioId: smp-SM217
   enumId: TREVENANT_DUSKNOIR_GX_SM217
@@ -3907,4 +5831,477 @@ cards:
   resistances:
   - type: F
     value: '-20'
+  rarity: Promo
+- id: 410-SM218
+  pioId: smp-SM218
+  enumId: BUZZWOLE_SM218
+  name: Buzzwole
+  number: SM218
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Beast Boost
+    text: This Pokémon's attacks do 20 more damage to your opponent's Active Pokémon
+      for each Prize card you have taken (before applying Weakness and Resistance).
+  moves:
+  - cost: [G, C]
+    name: Touchdown
+    damage: '60'
+    text: Heal 30 damage from this Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 410-SM219
+  pioId: smp-SM219
+  enumId: ENTEI_SM219
+  name: Entei
+  number: SM219
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [R, C]
+    name: Rally Back
+    damage: 30+
+    text: If any of your Pokémon were Knocked Out by damage from an opponent's attack
+      during their last turn, this attack does 90 more damage.
+  - cost: [R, R, C]
+    name: Fire Mane
+    damage: '100'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM220
+  pioId: smp-SM220
+  enumId: PHIONE_SM220
+  name: Phione
+  number: SM220
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Whirlpool Suction
+    text: Once during your turn (before your attack), if this Pokémon is on your Bench,
+      you may have your opponent switch their Active Pokémon with 1 of their Benched
+      Pokémon. If you do, discard all cards attached to this Pokémon and put it on
+      the bottom of your deck.
+  moves:
+  - cost: [W]
+    name: Rain Splash
+    damage: '10'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 410-SM221
+  pioId: smp-SM221
+  enumId: BLACEPHALON_SM221
+  name: Blacephalon
+  number: SM221
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 110
+  retreatCost: 2
+  moves:
+  - cost: [P, C]
+    name: Fireworks Bomb
+    text: Put 4 damage counters on your opponent's Pokémon in any way you like. If
+      your opponent has exactly 3 Prize cards remaining, put 12 damage counters on
+      them instead.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+- id: 410-SM222
+  pioId: smp-SM222
+  enumId: MISMAGIUS_SM222
+  name: Mismagius
+  number: SM222
+  types: [P]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Misdreavus
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [P]
+    name: Psywave
+    damage: 20x
+    text: This attack does 20 damage times the amount of Energy attached to your opponent's
+      Active Pokémon.
+  - cost: [C, C]
+    name: Astonish
+    damage: '40'
+    text: Choose a random card from your opponent's hand. Your opponent reveals that
+      card and shuffles it into their deck.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-20'
+  rarity: Promo
+- id: 410-SM223
+  pioId: smp-SM223
+  enumId: TERRAKION_SM223
+  name: Terrakion
+  number: SM223
+  types: [F]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 140
+  retreatCost: 4
+  moves:
+  - cost: [F, C, C]
+    name: Cavern Counter
+    damage: 50+
+    text: If all of your Benched Pokémon have at least 1 damage counter on them, this
+      attack does 150 more damage.
+  - cost: [F, F, C, C]
+    name: Boulder Crush
+    damage: '110'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+  copyOf: 410-SM205
+  copyType: Reprint
+- id: 410-SM224
+  pioId: smp-SM224
+  enumId: CELEBI_SM224
+  name: Celebi
+  number: SM224
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Call for Greatness
+    text: Search your deck for up to 3 Pokémon-GX with different names, reveal them,
+      and put them into your hand. Then, shuffle your deck.
+  - cost: [P, C, C]
+    name: Psy Bolt
+    damage: '40'
+    text: Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+- id: 410-SM225
+  pioId: smp-SM225
+  enumId: VICTINI_SM225
+  name: Victini
+  number: SM225
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Victory Sign
+    text: Search your deck for up to 2 basic Energy cards of different types and attach
+      them to your Pokémon in any way you like. Then, shuffle your deck.
+  - cost: [R]
+    name: Flare
+    damage: '20'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM226
+  pioId: smp-SM226
+  enumId: CHARIZARD_SM226
+  name: Charizard
+  number: SM226
+  types: [R]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Charmeleon
+  hp: 150
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Roaring Resolve
+    text: Once during your turn (before your attack), you may put 2 damage counters
+      on this Pokémon. If you do, search your deck for up to 2 [R] Energy cards and
+      attach them to this Pokémon. Then, shuffle your deck.
+  moves:
+  - cost: [R, R]
+    name: Continuous Blaze Ball
+    damage: 30+
+    text: Discard all [R] Energy from this Pokémon. This attack does 50 more damage
+      for each card you discarded in this way.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+  copyOf: 410-SM158
+  copyType: Reprint
+- id: 410-SM227
+  pioId: smp-SM227
+  enumId: PIKACHU_SM227
+  name: Pikachu
+  number: SM227
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Quick Attack
+    damage: 10+
+    text: Flip a coin. If heads, this attack does 10 more damage.
+  - cost: [L, L, C]
+    name: Thunderbolt
+    damage: '80'
+    text: Discard all Energy from this Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM228
+  pioId: smp-SM228
+  enumId: ARMORED_MEWTWO_SM228
+  name: Armored Mewtwo
+  number: SM228
+  types: [P]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 120
+  retreatCost: 3
+  moves:
+  - cost: [P, P, P]
+    name: Psychic Raid
+    damage: '130'
+    text: This Pokémon can’t attack during your next turn.
+  weaknesses:
+  - type: P
+    value: x2
+  rarity: Promo
+- id: 410-SM229
+  pioId: smp-SM229
+  enumId: VENUSAUR_SNIVY_GX_SM229
+  name: Venusaur & Snivy-GX
+  number: SM229
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 270
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Shining Vine
+    text: Once during your turn, if this Pokémon is your Active Pokémon, when you
+      attach a [G] Energy card from your hand to it, you may switch 1 of your opponent’s
+      Benched Pokémon with their Active Pokémon.
+  moves:
+  - cost: [G, C, C, C]
+    name: Forest Dump
+    damage: '160'
+  - cost: [C, C, C]
+    name: Solar Plant GX
+    text: This attack does 50 damage to each of your opponent's Pokémon. If this Pokémon
+      has at least 2 extra Energy attached to it (in addition to this attack's cost),
+      heal all damage from all of your Pokémon. (Don't apply Weakness and Resistance
+      for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 410-SM230
+  pioId: smp-SM230
+  enumId: CHARIZARD_BRAIXEN_GX_SM230
+  name: Charizard & Braixen-GX
+  number: SM230
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX, TAG_TEAM]
+  hp: 270
+  retreatCost: 3
+  moves:
+  - cost: [R, R, R, C]
+    name: Brilliant Flare
+    damage: '180'
+    text: You may search your deck for up to 3 cards and put them into your hand.
+      Then, shuffle your deck.
+  - cost: [R]
+    name: Crimson Flame Pillar GX
+    text: Attach 5 basic Energy cards from your discard pile to your Pokémon in any
+      way you like. If this Pokémon has at least 1 extra Energy attached to it (in
+      addition to this attack's cost), your opponent's Active Pokémon is now Burned
+      and Confused. (You can’t use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 410-SM231
+  pioId: smp-SM231
+  enumId: CHAMPIONS_FESTIVAL_SM231
+  name: Champions Festival
+  number: SM231
+  superType: TRAINER
+  subTypes: [STADIUM]
+  rarity: Promo
+  text: ['Once during each player''s turn, if that player has 6 Pokémon in play, he
+      or she may heal 10 damage from each of his or her Pokémon.']
+  copyOf: 410-SM148
+  copyType: Reprint
+- id: 410-SM232
+  pioId: smp-SM232
+  enumId: PIKACHU_GX_SM232
+  name: Pikachu-GX
+  number: SM232
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 160
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Agility
+    damage: '20'
+    text: Flip a coin. If heads, prevent all effects of attacks, including damage,
+      done to this Pokémon during your opponent’s next turn.
+  - cost: [L, L, C]
+    name: Volt Tackle
+    damage: '150'
+    text: This Pokémon does 30 damage to itself.
+  - cost: [L, L, C]
+    name: Tail Break GX
+    damage: '100'
+    text: Your opponent’s Active Pokémon is now Paralyzed. (You can’t use more than
+      1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM233
+  pioId: smp-SM233
+  enumId: EEVEE_GX_SM233
+  name: Eevee-GX
+  number: SM233
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_GX]
+  hp: 160
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Ascension DNA
+    text: Once during your turn (before your attack), if you have a Pokémon in your
+      hand that evolves from Eevee, you may put that card onto this Pokémon to evolve
+      it. Before evolving, heal all damage from this Pokémon. You can't use this Ability
+      during your first turn or the turn this Pokémon was put into play.
+  moves:
+  - cost: [C, C, C]
+    name: Boost Dash
+    damage: '100'
+  - cost: [C]
+    name: Joy Maker GX
+    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+      1 GX attack in a game.)
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+  copyOf: 410-SM174
+  copyType: Reprint
+- id: 410-SM234
+  pioId: smp-SM234
+  enumId: PIKACHU_SM234
+  name: Pikachu
+  number: SM234
+  types: [L]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Find a Friend
+    text: Flip a coin. If heads, search your deck for a Pokémon, reveal it, and put
+      it into your hand. Then, shuffle your deck.
+  - cost: [C, C]
+    name: Gnaw
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  resistances:
+  - type: M
+    value: '-20'
+  rarity: Promo
+- id: 410-SM235
+  pioId: smp-SM235
+  enumId: EEVEE_SM235
+  name: Eevee
+  number: SM235
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Running Charge
+    damage: 30x
+    text: Flip a coin until you get tails. This attack does 30 damage for each heads.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 410-SM236
+  pioId: smp-SM236
+  enumId: ALOLAN_SANDSLASH_GX_SM236
+  name: Alolan Sandslash-GX
+  number: SM236
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
+  evolvesFrom: AlolanSandshrew
+  hp: 200
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Spiky Shield
+    text: If this Pokémon is your Active Pokémon and is damaged by an opponent's attack
+      (even if this Pokémon is Knocked Out), put 3 damage counters on the Attacking
+      Pokémon.
+  moves:
+  - cost: [W, C, C]
+    name: Frost Breath
+    damage: '120'
+  - cost: [W, C, C]
+    name: Spiky Storm GX
+    text: This attack does 100 damage to each of your opponent's Pokémon that has
+      any damage counters on it. (Don't apply Weakness and Resistance for Benched
+      Pokémon.) (You can't use more than 1 GX attack in a game.)
+  weaknesses:
+  - type: M
+    value: x2
   rarity: Promo

--- a/src/main/resources/cards/410-sun_moon_promos.yaml
+++ b/src/main/resources/cards/410-sun_moon_promos.yaml
@@ -6283,7 +6283,7 @@ cards:
   types: [W]
   superType: POKEMON
   subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
-  evolvesFrom: AlolanSandshrew
+  evolvesFrom: Alolan Sandshrew
   hp: 200
   retreatCost: 2
   abilities:


### PR DESCRIPTION
I can add the scans that may be missing, although I am aware we need to re-structure our scans on the server first before that is done. Regardless, I went ahead and added all the missing stuff. There are still some promos from the latest box that was just released that need added, but I still need to look into any promos that would need implemented before doing all of that. Not to mention, I'll have to make the db entries for the new box myself since neither pokemontcg.io or Kirby's repo has the new promos on their files.

This also marks every missing promo card.