### PR TITLE
Revert TURFFIELD_STADIUM_170's ID back to TURRFIELD_170

### DIFF
--- a/src/main/resources/cards/431-rebel-clash.yaml
+++ b/src/main/resources/cards/431-rebel-clash.yaml
@@ -3748,7 +3748,7 @@ cards:
       from their discard pile into their hand.']
 - id: 431-170
   pioId: swsh2-170
-  enumId: TURFFIELD_STADIUM_170
+  enumId: TURRFIELD_170
   name: Turffield Stadium
   number: '170'
   superType: TRAINER


### PR DESCRIPTION
Some issues were occurring on the engine due to the ID being changed.