### PR TITLE
Sword and Shield Promos

### DIFF
--- a/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -1,0 +1,635 @@
+set:
+  id: '429'
+  name: Sword & Shield Promos
+  enumId: SWORD_SHIELD_PROMOS
+  abbr: SWSH
+cards:
+- id: 429-1
+  enumId: GROOKEY_SWSH01
+  name: Grookey
+  number: '1'
+  types: [G]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [G, C]
+    name: Branch Poke
+    damage: '30'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 429-2
+  enumId: SCORBUNNY_SWSH02
+  name: Scorbunny
+  number: '2'
+  types: [R]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [R]
+    name: Super Singe
+    damage: '30'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Burned.
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 429-3
+  enumId: SOBBLE_SWSH03
+  name: Sobble
+  number: '3'
+  types: [W]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [W, C]
+    name: Bind
+    damage: '20'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+- id: 429-4
+  enumId: MEOWTH_V_SWSH04
+  name: Meowth V
+  number: '4'
+  types: [C]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC, POKEMON_V]
+  hp: 180
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Pay Day
+    damage: '30'
+    text: Draw a card.
+  - cost: [C, C, C]
+    name: Slashing Claw
+    damage: '130'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-5
+  enumId: MEOWTH_VMAX_SWSH05
+  name: Meowth VMAX
+  number: '5'
+  types: [C]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, EVOLUTION, POKEMON_VMAX]
+  hp: 300
+  retreatCost: 2
+  moves:
+  - cost: [C, C, C, C]
+    name: G-Max Gold Rush
+    damage: '200'
+    text: Draw 3 cards.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-6
+  enumId: RILLABOOM_SWSH06
+  name: Rillaboom
+  number: '6'
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Thwackey
+  hp: 170
+  retreatCost: 3
+  abilities:
+  - type: Ability
+    name: Voltage Beat
+    text: Once during your turn, you may search your deck for up to 2 [G] Energy cards
+      and attach them to 1 of your Pokémon. Then, shuffle your deck.
+  moves:
+  - cost: [G, G, G, C]
+    name: Hammer In
+    damage: '140'
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 429-7
+  enumId: FROSMOTH_SWSH07
+  name: Frosmoth
+  number: '7'
+  types: [W]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Snom
+  hp: 90
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Ice Dance
+    text: As often as you like during your turn, you may attach a [W] Energy card
+      from your hand to 1 of your Benched [W] Pokémon.
+  moves:
+  - cost: [W, C]
+    name: Aurora Beam
+    damage: '30'
+  weaknesses:
+  - type: M
+    value: x2
+  rarity: Promo
+- id: 429-8
+  enumId: GALARIAN_PERRSERKER_SWSH08
+  name: Galarian Perrserker
+  number: '8'
+  types: [M]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Galarian Meowth
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: 'Steely Spirit'
+    text: Your [M] Pokémon's attacks do 20 more damage to your opponent's Active Pokémon
+      (before applying Weakness and Resistance).
+  moves:
+  - cost: [M, M, C]
+    name: Metal Claw
+    damage: '70'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-20'
+  rarity: Promo
+- id: 429-9
+  enumId: CINCCINO_SWSH09
+  name: Cinccino
+  number: '9'
+  types: [C]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Minccino
+  hp: 90
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Make Do
+    text: You must discard a card from your hand in order to use this Ability. Once
+      during your turn, you may draw 2 cards.
+  moves:
+  - cost: [C]
+    name: Energy Assist
+    damage: '40'
+    text: Attach a basic Energy card from your discard pile to 1 of your Benched Pokémon.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-10
+  enumId: GOSSIFLEUR_SWSH10
+  name: Gossifleur
+  number: '10'
+  types: [G]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 50
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Sing
+    text: Your opponent's Active Pokémon is now Asleep.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 429-11
+  enumId: WOOLOO_SWSH11
+  name: Wooloo
+  number: '11'
+  types: [C]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Defense Curl
+    text: Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn.
+  - cost: [C, C]
+    name: Headbutt
+    damage: '20'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-12
+  enumId: MORPEKO_SWSH12
+  name: Morpeko
+  number: '12'
+  types: [L]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [L, C, C]
+    name: Thunder Shock
+    damage: '60'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-13
+  enumId: GALARIAN_PONYTA_SWSH13
+  name: Galarian Ponyta
+  number: '13'
+  types: [P]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Heal Pulse
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  - cost: [P, C]
+    name: Flop
+    damage: '20'
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+- id: 429-14
+  enumId: RILLABOOM_V_SWSH14
+  name: Rillaboom V
+  number: '14'
+  types: [G]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 3
+  moves:
+  - cost: [G]
+    name: Forest Feast
+    text: Search your deck for up to 2 Basic [G] Pokémon and put them onto your Bench.
+      Then, shuffle your deck.
+  - cost: [G, G, G, C]
+    name: Wood Hammer
+    damage: '220'
+    text: This Pokémon also does 30 damage to itself.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 429-15
+  enumId: CINDERACE_V_SWSH15
+  name: Cinderace V
+  number: '15'
+  types: [R]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Field Runner
+    text: If a Stadium is in play, this Pokémon has no Retreat Cost.
+  moves:
+  - cost: [R, R, C]
+    name: Crimson Legs
+    damage: '140'
+  weaknesses:
+  - type: W
+    value: x2
+  rarity: Promo
+- id: 429-16
+  enumId: INTELEON_V_SWSH16
+  name: Inteleon V
+  number: '16'
+  types: [W]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 200
+  retreatCost: 2
+  moves:
+  - cost: [W]
+    name: Snipe Shot
+    text: This attack does 40 damage to 1 of your opponent's Pokémon. (Don’t apply
+      Weakness and Resistance for Benched Pokémon.)
+  - cost: [W, W, C]
+    name: Aqua Report
+    damage: '130'
+    text: Your opponent reveals their hand.
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+- id: 429-17
+  enumId: TOXTRICITY_V_SWSH16
+  name: Toxtricity V
+  number: '17'
+  types: [L]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC, POKEMON_V]
+  hp: 210
+  retreatCost: 2
+  moves:
+  - cost: [C]
+    name: Energize
+    text: Attach a [L] Energy card from your discard pile to this Pokémon.
+  - cost: [L, L, C]
+    name: Venom Slap
+    damage: '120'
+    text: Your opponent's Active Pokémon is now Poisoned.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-20
+  enumId: PIKACHU_SWSH20
+  name: Pikachu
+  number: '20'
+  types: [L]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 70
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Iron Tail
+    damage: '30x'
+    text: Flip a coin until you get tails. This attack does 30 damage for each heads.
+  - cost: [L, L, C]
+    name: Electro Ball
+    damage: '60'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-21
+  enumId: POLTEAGEIST_V_SWSH21
+  name: Polteageist V
+  number: '21'
+  types: [P]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC, POKEMON_V]
+  hp: 170
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Teapot of Surprises
+    text: If this Pokémon is in the Active Spot and is damaged by an opponent’s attack
+      (even if it is Knocked Out), choose a random card from your opponent’s hand.
+      Your opponent reveals that card and puts it on the bottom of their deck.
+  moves:
+  - cost: [P, C, C]
+    name: Mind Bend
+    damage: '100'
+    text: Your opponent's Active Pokémon is now Confused.
+  weaknesses:
+  - type: D
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+- id: 429-22
+  enumId: FLAPPLE_SWSH22
+  name: Flapple
+  number: '22'
+  types: [G]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Applin
+  hp: 80
+  retreatCost: 1
+  abilities:
+  - type: Ability
+    name: Apple Drop
+    text: Once during your turn, you may put 2 damage counters on 1 of your opponent’s
+      Pokémon. If you placed any damage counters in this way, shuffle this Pokémon
+      and all attached cards into your deck.
+  moves:
+  - cost: [C, C]
+    name: Acid Spray
+    damage: '60'
+    text: Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  rarity: Promo
+- id: 429-23
+  enumId: LUXRAY_SWSH23
+  name: Luxray
+  number: '23'
+  types: [L]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Luxio
+  hp: 160
+  retreatCost: 1
+  moves:
+  - cost: [L]
+    name: Raid
+    damage: 60+
+    text: If this Pokémon evolved from Luxio during this turn, this attack does 100
+      more damage.
+  - cost: [L, C]
+    name: Head Bolt
+    damage: '120'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-24
+  enumId: COALOSSAL_SWSH24
+  name: Coalossal
+  number: '24'
+  types: [F]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE2]
+  evolvesFrom: Carkol
+  hp: 160
+  retreatCost: 4
+  abilities:
+  - type: Ability
+    name: Tar Generator
+    text: Once during your turn, you may attach a [R] Energy card, a [F] Energy card,
+      or 1 of each from your discard pile to your Pokémon in any way you like.
+  moves:
+  - cost: [F, C, C, C]
+    name: Flaming Avalanche
+    damage: '130'
+  weaknesses:
+  - type: G
+    value: x2
+  rarity: Promo
+- id: 429-25
+  enumId: GARBODOR_SWSH25
+  name: Garbodor
+  number: '25'
+  types: [D]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Trubbish
+  hp: 120
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Poisonous Puddle
+    text: Once during your turn, if a Stadium is in play, you may make your opponent's
+      Active Pokémon Poisoned.
+  moves:
+  - cost: [D, C, C]
+    name: Sludge Bomb
+    damage: '80'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-26
+  enumId: MANTINE_SWSH26
+  name: Mantine
+  number: '26'
+  types: [W]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [W]
+    name: Water Reserve
+    text: Search your deck for up to 3 [W] Energy cards, reveal them, and
+      put them into your hand. Then, shuffle your deck.
+  - cost: [W, W]
+    name: Wave Splash
+    damage: '60'
+  weaknesses:
+  - type: L
+    value: x2
+  rarity: Promo
+- id: 429-27
+  enumId: NOCTOWL_SWSH27
+  name: Noctowl
+  number: '27'
+  types: [C]
+  superType: POKEMON
+  subTypes: [EVOLUTION, STAGE1]
+  evolvesFrom: Hoothoot
+  hp: 110
+  retreatCost: 1
+  moves:
+  - cost: [C, C]
+    name: Wing Attack
+    damage: '40'
+  - cost: [C, C, C]
+    name: Carry Off
+    text: Choose 1 of your opponent's Benched Pokémon. They shuffle that Pokémon and
+      all attached cards into their deck. Then, shuffle this Pokémon and all attached
+      cards into your deck.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+- id: 429-28
+  enumId: DURALUDON_SWSH28
+  name: Duraludon
+  number: '28'
+  types: [M]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [M, C, C]
+    name: Metal Claw
+    damage: '70'
+  - cost: [M, C, C, C]
+    name: Steel Beam
+    text: This Pokémon also does 40 damage to itself.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+- id: 429-29
+  enumId: RAYQUAZA_SWSH29
+  name: Rayquaza
+  number: '29'
+  types: [C]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 130
+  retreatCost: 2
+  moves:
+  - cost: [C, C]
+    name: Jaw Lock
+    damage: '30'
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+  - cost: [C, C, C]
+    name: Power Blast
+    text: Discard an Energy from this Pokémon.
+  weaknesses:
+  - type: L
+    value: x2
+  resistances:
+  - type: F
+    value: '-30'
+  rarity: Promo
+- id: 429-31
+  enumId: MORPEKO_SWSH31
+  name: Morpeko
+  number: '31'
+  types: [L]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 80
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Famished
+    text: Draw a card.
+  - cost: [L, C]
+    name: Thunder Shock
+    damage: '40'
+    text: Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 429-32
+  enumId: SNORLAX_SWSH32
+  name: Snorlax
+  number: '32'
+  types: [C]
+  superType: POKEMON
+  subTypes: [NOT_IMPLEMENTED, BASIC]
+  hp: 150
+  retreatCost: 4
+  moves:
+  - cost: [C, C, C]
+    name: Rolling Tackle
+    damage: '80'
+  - cost: [C, C, C, C]
+    name: Heavy Impact
+    damage: '130'
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo

--- a/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -529,7 +529,7 @@ cards:
   number: '26'
   types: [W]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 110
   retreatCost: 1
   moves:
@@ -649,7 +649,7 @@ cards:
   number: '32'
   types: [C]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 150
   retreatCost: 4
   moves:

--- a/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -1,10 +1,12 @@
 set:
   id: '429'
   name: Sword & Shield Promos
+  pioId: swsh
   enumId: SWORD_SHIELD_PROMOS
   abbr: SWSH
 cards:
 - id: 429-1
+  pioId: swsh-1
   enumId: GROOKEY_SWSH01
   name: Grookey
   number: '1'
@@ -22,6 +24,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-2
+  pioId: swsh-2
   enumId: SCORBUNNY_SWSH02
   name: Scorbunny
   number: '2'
@@ -40,6 +43,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-3
+  pioId: swsh-3
   enumId: SOBBLE_SWSH03
   name: Sobble
   number: '3'
@@ -58,6 +62,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-4
+  pioId: swsh-4
   enumId: MEOWTH_V_SWSH04
   name: Meowth V
   number: '4'
@@ -79,6 +84,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-5
+  pioId: swsh-5
   enumId: MEOWTH_VMAX_SWSH05
   name: Meowth VMAX
   number: '5'
@@ -97,6 +103,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-6
+  pioId: swsh-6
   enumId: RILLABOOM_SWSH06
   name: Rillaboom
   number: '6'
@@ -120,6 +127,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-7
+  pioId: swsh-7
   enumId: FROSMOTH_SWSH07
   name: Frosmoth
   number: '7'
@@ -143,6 +151,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-8
+  pioId: swsh-8
   enumId: GALARIAN_PERRSERKER_SWSH08
   name: Galarian Perrserker
   number: '8'
@@ -169,6 +178,7 @@ cards:
     value: '-20'
   rarity: Promo
 - id: 429-9
+  pioId: swsh-9
   enumId: CINCCINO_SWSH09
   name: Cinccino
   number: '9'
@@ -193,6 +203,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-10
+  pioId: swsh-10
   enumId: GOSSIFLEUR_SWSH10
   name: Gossifleur
   number: '10'
@@ -210,6 +221,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-11
+  pioId: swsh-11
   enumId: WOOLOO_SWSH11
   name: Wooloo
   number: '11'
@@ -230,6 +242,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-12
+  pioId: swsh-12
   enumId: MORPEKO_SWSH12
   name: Morpeko
   number: '12'
@@ -248,6 +261,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-13
+  pioId: swsh-13
   enumId: GALARIAN_PONYTA_SWSH13
   name: Galarian Ponyta
   number: '13'
@@ -271,6 +285,7 @@ cards:
     value: '-30'
   rarity: Promo
 - id: 429-14
+  pioId: swsh-14
   enumId: RILLABOOM_V_SWSH14
   name: Rillaboom V
   number: '14'
@@ -293,6 +308,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-15
+  pioId: swsh-15
   enumId: CINDERACE_V_SWSH15
   name: Cinderace V
   number: '15'
@@ -314,6 +330,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-16
+  pioId: swsh-16
   enumId: INTELEON_V_SWSH16
   name: Inteleon V
   number: '16'
@@ -336,6 +353,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-17
+  pioId: swsh-17
   enumId: TOXTRICITY_V_SWSH16
   name: Toxtricity V
   number: '17'
@@ -357,6 +375,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-20
+  pioId: swsh-20
   enumId: PIKACHU_SWSH20
   name: Pikachu
   number: '20'
@@ -378,6 +397,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-21
+  pioId: swsh-21
   enumId: POLTEAGEIST_V_SWSH21
   name: Polteageist V
   number: '21'
@@ -405,6 +425,7 @@ cards:
     value: '-30'
   rarity: Promo
 - id: 429-22
+  pioId: swsh-22
   enumId: FLAPPLE_SWSH22
   name: Flapple
   number: '22'
@@ -430,6 +451,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-23
+  pioId: swsh-23
   enumId: LUXRAY_SWSH23
   name: Luxray
   number: '23'
@@ -453,6 +475,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-24
+  pioId: swsh-24
   enumId: COALOSSAL_SWSH24
   name: Coalossal
   number: '24'
@@ -476,6 +499,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-25
+  pioId: swsh-25
   enumId: GARBODOR_SWSH25
   name: Garbodor
   number: '25'
@@ -499,6 +523,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-26
+  pioId: swsh-26
   enumId: MANTINE_SWSH26
   name: Mantine
   number: '26'
@@ -520,6 +545,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-27
+  pioId: swsh-27
   enumId: NOCTOWL_SWSH27
   name: Noctowl
   number: '27'
@@ -546,6 +572,7 @@ cards:
     value: '-30'
   rarity: Promo
 - id: 429-28
+  pioId: swsh-28
   enumId: DURALUDON_SWSH28
   name: Duraludon
   number: '28'
@@ -569,6 +596,7 @@ cards:
     value: '-30'
   rarity: Promo
 - id: 429-29
+  pioId: swsh-29
   enumId: RAYQUAZA_SWSH29
   name: Rayquaza
   number: '29'
@@ -593,6 +621,7 @@ cards:
     value: '-30'
   rarity: Promo
 - id: 429-31
+  pioId: swsh-31
   enumId: MORPEKO_SWSH31
   name: Morpeko
   number: '31'
@@ -614,6 +643,7 @@ cards:
     value: x2
   rarity: Promo
 - id: 429-32
+  pioId: swsh-32
   enumId: SNORLAX_SWSH32
   name: Snorlax
   number: '32'

--- a/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -84,7 +84,7 @@ cards:
   number: '5'
   types: [C]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, POKEMON_VMAX]
+  subTypes: [NOT_IMPLEMENTED, EVOLUTION, VMAX]
   hp: 300
   retreatCost: 2
   moves:

--- a/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -175,7 +175,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Promo
 - id: 429-9
   pioId: swsh-9


### PR DESCRIPTION
Starting to become necessary as we are quite behind now on promos. Thankfully I'd say a good amount of them are reprints, although there are still some important ones (Toxtricity V, Polteageist V).

I used the set ID "429" since "430" was taken by Sword and Shield, which I figure would cause conflicts if I renamed the file.

Does not include any legality in formats.yaml due to the pre-existing PR for formats *(will include changes in that PR if this gets merged)*

Please comment on any errors.

**NOTE**: I made this file myself and didn't take it from either pokemontcg.io or kirby's repo. I'll modify this with the proper ptcgio fields when pokemontcg.io has the promos up on their site.