### PR TITLE
Fix resistances in Sword and Shield

### DIFF
--- a/src/main/resources/cards/430-sword_shield.yaml
+++ b/src/main/resources/cards/430-sword_shield.yaml
@@ -1772,7 +1772,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-82
   pioId: swsh1-82
@@ -1800,7 +1800,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Rare
 - id: 430-83
   pioId: swsh1-83
@@ -1822,7 +1822,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-84
   pioId: swsh1-84
@@ -1848,7 +1848,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Uncommon
 - id: 430-85
   pioId: swsh1-85
@@ -1876,7 +1876,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Rare Holo
 - id: 430-86
   pioId: swsh1-86
@@ -1902,7 +1902,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Rare Holo
 - id: 430-87
   pioId: swsh1-87
@@ -1926,7 +1926,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-88
   pioId: swsh1-88
@@ -1954,7 +1954,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Rare
 - id: 430-89
   pioId: swsh1-89
@@ -1975,7 +1975,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-90
   pioId: swsh1-90
@@ -2002,7 +2002,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Rare
 - id: 430-91
   pioId: swsh1-91
@@ -2029,7 +2029,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Rare Holo
 - id: 430-92
   pioId: swsh1-92
@@ -2819,7 +2819,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-128
   pioId: swsh1-128
@@ -2846,7 +2846,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Rare Holo
 - id: 430-129
   pioId: swsh1-129
@@ -2872,7 +2872,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-130
   pioId: swsh1-130
@@ -2893,7 +2893,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-131
   pioId: swsh1-131
@@ -2920,7 +2920,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Uncommon
 - id: 430-132
   pioId: swsh1-132
@@ -2948,7 +2948,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Uncommon
 - id: 430-133
   pioId: swsh1-133
@@ -2972,7 +2972,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-134
   pioId: swsh1-134
@@ -2998,7 +2998,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Uncommon
 - id: 430-135
   pioId: swsh1-135
@@ -3026,7 +3026,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Rare
 - id: 430-136
   pioId: swsh1-136
@@ -3048,7 +3048,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-137
   pioId: swsh1-137
@@ -3075,7 +3075,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Rare Holo
 - id: 430-138
   pioId: swsh1-138
@@ -3103,7 +3103,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Rare Holo
 - id: 430-139
   pioId: swsh1-139
@@ -3129,7 +3129,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Rare Holo
 - id: 430-140
   pioId: swsh1-140
@@ -3218,7 +3218,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-144
   pioId: swsh1-144
@@ -3245,7 +3245,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Rare
 - id: 430-145
   pioId: swsh1-145
@@ -3376,7 +3376,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Common
 - id: 430-151
   pioId: swsh1-151
@@ -3403,7 +3403,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Uncommon
 - id: 430-152
   pioId: swsh1-152
@@ -3495,7 +3495,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Rare Holo
 - id: 430-156
   pioId: swsh1-156
@@ -3929,7 +3929,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Ultra Rare
   copyOf: 430-86
   copyType: Full Art
@@ -3958,7 +3958,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Ultra Rare
   copyOf: 430-91
   copyType: Full Art
@@ -4038,7 +4038,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Ultra Rare
   copyOf: 430-138
   copyType: Full Art
@@ -4066,7 +4066,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Ultra Rare
   copyOf: 430-139
   copyType: Full Art
@@ -4120,7 +4120,7 @@ cards:
     value: x2
   resistances:
   - type: F
-    value: '-20'
+    value: '-30'
   rarity: Ultra Rare
   copyOf: 430-155
   copyType: Full Art
@@ -4334,7 +4334,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Secret
   copyOf: 430-138
   copyType: Secret Art
@@ -4362,7 +4362,7 @@ cards:
     value: x2
   resistances:
   - type: G
-    value: '-20'
+    value: '-30'
   rarity: Secret
   copyOf: 430-139
   copyType: Secret Art


### PR DESCRIPTION
Resistances were "-20" instead of "-30" as the change was made. This was probably because kirby's repo automatically inserted them as such instead of putting -30.