### PR TITLE
Sword and Shield series cleanup/changes

### DIFF
--- a/src/main/resources/cards/410-sun_moon_promos.yaml
+++ b/src/main/resources/cards/410-sun_moon_promos.yaml
@@ -3796,7 +3796,7 @@ cards:
   - cost: [R, C, C]
     name: Flame Jet GX
     text: This attack does 120 damage to 1 of your opponent's Pokémon. (Don't apply
-      Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX
+      Weakness and Resistance for Benched Pokémon.) (You can''t use more than 1 GX
       attack in a game.)
   weaknesses:
   - type: Y
@@ -3818,7 +3818,7 @@ cards:
   - type: Ability
     name: Dragon Wind
     text: If this Pokémon is your Active Pokémon, once during your turn (before your
-      attack), you may switch 1 of your opponent’s Benched Pokémon with their Active
+      attack), you may switch 1 of your opponent''s Benched Pokémon with their Active
       Pokémon.
   moves:
   - cost: [R, W, C, C]
@@ -4101,7 +4101,7 @@ cards:
     name: Distortion Door
     text: Once during your turn (before your attack), if this Pokémon is in your discard
       pile, you may put it onto your Bench. If you do, put 1 damage counter on 2 of
-      your opponent’s Benched Pokémon.
+      your opponent''s Benched Pokémon.
   moves:
   - cost: [P, P, C]
     name: Shadow Impact
@@ -4128,7 +4128,7 @@ cards:
   - type: Ability
     name: Charmed Charm
     text: Whenever you attach a Pokémon Tool card that has "Fairy Charm" in its name
-      from your hand to this Pokémon during your turn, you may leave your opponent’s
+      from your hand to this Pokémon during your turn, you may leave your opponent''s
       Active Pokémon Confused.
   moves:
   - cost: [Y, C, C]
@@ -4312,7 +4312,7 @@ cards:
     name: Thunderous Assault
     damage: 10+
     text: If this Pokémon was on the Bench and became your Active Pokémon this turn,
-      this attack does 70 more damage. This attack’s damage isn't affected by Weakness.
+      this attack does 70 more damage. This attack''s damage isn't affected by Weakness.
   weaknesses:
   - type: L
     value: x2
@@ -4335,7 +4335,7 @@ cards:
   - type: Ability
     name: Queen's Call
     text: Once during your turn (before your attack), you may search your deck for
-      a Pokémon that isn’t a Pokémon-GX or Pokémon-EX, reveal it, and put it into
+      a Pokémon that isn''t a Pokémon-GX or Pokémon-EX, reveal it, and put it into
       your hand. Then, shuffle your deck.
   moves:
   - cost: [C, C, C]
@@ -4540,7 +4540,7 @@ cards:
     text: If this Pokémon has at least 3 extra [L] Energy attached to it (in addition
       to this attack's cost), this attack does 170 damage to 1 of your opponent's
       Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)
-      (You can’t use more than 1 GX attack in a game.)
+      (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: F
     value: x2
@@ -4688,7 +4688,7 @@ cards:
     name: Swift Run GX
     damage: '110'
     text: Prevent all effects of attacks, including damage, done to this Pokémon during
-      your opponent's next turn. (You can’t use more than 1 GX attack in a game.)
+      your opponent's next turn. (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: F
     value: x2
@@ -4720,7 +4720,7 @@ cards:
     damage: '100'
   - cost: [C]
     name: Joy Maker GX
-    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+    text: Put 3 cards from your discard pile into your hand. (You can''t use more than
       1 GX attack in a game.)
   weaknesses:
   - type: F
@@ -4750,7 +4750,7 @@ cards:
     damage: '100'
   - cost: [C]
     name: Joy Maker GX
-    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+    text: Put 3 cards from your discard pile into your hand. (You can''t use more than
       1 GX attack in a game.)
   weaknesses:
   - type: F
@@ -4780,7 +4780,7 @@ cards:
     damage: '100'
   - cost: [C]
     name: Joy Maker GX
-    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+    text: Put 3 cards from your discard pile into your hand. (You can''t use more than
       1 GX attack in a game.)
   weaknesses:
   - type: F
@@ -4837,7 +4837,7 @@ cards:
   - cost: [M]
     name: Iron Force GX
     text: Attach any number of [M] Energy cards from your discard pile to this Pokémon.
-      (You can’t use more than 1 GX attack in a game.)
+      (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: R
     value: x2
@@ -5010,7 +5010,7 @@ cards:
   - cost: [R, R, C]
     name: Bursting Inferno
     damage: '100'
-    text: Your opponent’s Active Pokémon is now Burned.
+    text: Your opponent''s Active Pokémon is now Burned.
   weaknesses:
   - type: W
     value: x2
@@ -5045,7 +5045,7 @@ cards:
   number: SM187
   types: [R]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, POKEMON_GX, STAGE1]
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE1]
   evolvesFrom: Cubone
   hp: 200
   retreatCost: 2
@@ -5084,7 +5084,7 @@ cards:
   - cost: [C]
     name: Split Spiral Punch
     damage: '20'
-    text: Your opponent’s Active Pokémon is now Confused.
+    text: Your opponent''s Active Pokémon is now Confused.
   - cost: [C, C, C]
     name: Enraged Strike
     damage: 80+
@@ -5124,7 +5124,7 @@ cards:
   - cost: [W]
     name: Giant Geyser GX
     text: Attach any number of [W] Energy cards from your hand to your Pokémon in
-      any way you like. (You can’t use more than 1 GX attack in a game.)
+      any way you like. (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: G
     value: x2
@@ -5175,7 +5175,7 @@ cards:
     name: Miraculous Duo GX
     damage: '200'
     text: If this Pokémon has at least 1 extra Energy attached to it (in addition
-      to this attack’s cost), heal all damage from all of your Pokémon. (You can’t
+      to this attack''s cost), heal all damage from all of your Pokémon. (You can''t
       use more than 1 GX attack in a game.)
   weaknesses:
   - type: P
@@ -5227,7 +5227,7 @@ cards:
   moves:
   - cost: [C]
     name: Linear Attack
-    text: This attack does 40 damage to 1 of your opponent’s Pokémon. (Don’t apply
+    text: This attack does 40 damage to 1 of your opponent''s Pokémon. (Don''t apply
       Weakness and Resistance for Benched Pokémon.)
   - cost: [F, P, C]
     name: Calamitous Slash
@@ -5238,7 +5238,7 @@ cards:
     name: GG End GX
     text: Discard 1 of your opponent's Pokémon and all cards attached to it. If this
       Pokémon has at least 3 extra [F] Energy attached to it (in addition to this
-      attack’s cost), discard 2 of your opponent's Pokémon instead. (You can’t use
+      attack''s cost), discard 2 of your opponent's Pokémon instead. (You can''t use
       more than 1 GX attack in a game.)
   weaknesses:
   - type: Y
@@ -5251,7 +5251,7 @@ cards:
   number: SM194
   types: [L]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 90
   retreatCost: 2
   moves:
@@ -5273,7 +5273,7 @@ cards:
   number: SM195
   types: [R]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, POKEMON_GX, STAGE2]
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE2]
   evolvesFrom: Charmeleon
   hp: 250
   retreatCost: 4
@@ -5302,7 +5302,7 @@ cards:
   number: SM196
   types: [P]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX]
   hp: 190
   retreatCost: 2
   moves:
@@ -5313,7 +5313,7 @@ cards:
   - cost: [P, P, C, C]
     name: Reigning Pulse
     damage: '120'
-    text: Your opponent’s Active Pokémon is now Confused.
+    text: Your opponent''s Active Pokémon is now Confused.
   - cost: [P, P, C, C]
     name: Psychic Nova GX
     damage: '180'
@@ -5349,7 +5349,7 @@ cards:
   - cost: [W]
     name: Dark Mist GX
     text: Put 1 of your opponent's Benched Pokémon and all cards attached to it into
-      your opponent’s hand. (You can’t use more than 1 GX attack in a game.)
+      your opponent''s hand. (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: G
     value: x2
@@ -5511,7 +5511,7 @@ cards:
   - cost: [C, C]
     name: Barrier Attack
     damage: '30'
-    text: During your opponent’s next turn, this Pokémon takes 30 less damage from
+    text: During your opponent''s next turn, this Pokémon takes 30 less damage from
       attacks (after applying Weakness and Resistance).
   - cost: [P, P, C]
     name: Special Laser
@@ -5584,7 +5584,7 @@ cards:
   - cost: [F, F]
     name: Territorial Strike
     damage: '80'
-    text: If you don’t have a Stadium card in play, this attack does nothing.
+    text: If you don''t have a Stadium card in play, this attack does nothing.
   weaknesses:
   - type: W
     value: x2
@@ -5688,7 +5688,7 @@ cards:
   - cost: [R, R, C, C]
     name: Flare Blitz GX
     damage: '300'
-    text: (You can’t use more than 1 GX attack in a game.)
+    text: (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: W
     value: x2
@@ -5712,7 +5712,7 @@ cards:
   - cost: [W, W, W, C]
     name: Hyper Beam GX
     damage: '240'
-    text: (You can’t use more than 1 GX attack in a game.)
+    text: (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: L
     value: x2
@@ -5736,7 +5736,7 @@ cards:
   - cost: [L, L, C]
     name: Spark Ball GX
     damage: '200'
-    text: (You can’t use more than 1 GX attack in a game.)
+    text: (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: F
     value: x2
@@ -5816,7 +5816,7 @@ cards:
   - cost: [C]
     name: Critical Error GX
     text: Search your deck for up to 10 cards and discard them. Then, shuffle your
-      deck. (You can’t use more than 1 GX attack in a game.)
+      deck. (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: F
     value: x2
@@ -5840,7 +5840,7 @@ cards:
       cards and shuffles them into their deck.
   - cost: [P, C]
     name: Pale Moon GX
-    text: At the end of your opponent’s next turn, the Defending Pokémon will be Knocked
+    text: At the end of your opponent''s next turn, the Defending Pokémon will be Knocked
       Out. If this Pokémon has at least 1 extra [P] Energy attached to it (in addition
       to this attack's cost), discard all Energy from your opponent's Active Pokémon.
       (You can't use more than 1 GX attack in a game.)
@@ -5953,7 +5953,7 @@ cards:
   number: SM222
   types: [P]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, STAGE1]
+  subTypes: [EVOLUTION, STAGE1]
   evolvesFrom: Misdreavus
   hp: 110
   retreatCost: 1
@@ -6016,7 +6016,7 @@ cards:
   - cost: [P, C, C]
     name: Psy Bolt
     damage: '40'
-    text: Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.
+    text: Flip a coin. If heads, your opponent''s Active Pokémon is now Paralyzed.
   weaknesses:
   - type: P
     value: x2
@@ -6077,7 +6077,7 @@ cards:
   number: SM227
   types: [L]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 60
   retreatCost: 1
   moves:
@@ -6103,14 +6103,14 @@ cards:
   number: SM228
   types: [P]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 120
   retreatCost: 3
   moves:
   - cost: [P, P, P]
     name: Psychic Raid
     damage: '130'
-    text: This Pokémon can’t attack during your next turn.
+    text: This Pokémon can''t attack during your next turn.
   weaknesses:
   - type: P
     value: x2
@@ -6129,7 +6129,7 @@ cards:
   - type: Ability
     name: Shining Vine
     text: Once during your turn, if this Pokémon is your Active Pokémon, when you
-      attach a [G] Energy card from your hand to it, you may switch 1 of your opponent’s
+      attach a [G] Energy card from your hand to it, you may switch 1 of your opponent''s
       Benched Pokémon with their Active Pokémon.
   moves:
   - cost: [G, C, C, C]
@@ -6140,7 +6140,7 @@ cards:
     text: This attack does 50 damage to each of your opponent's Pokémon. If this Pokémon
       has at least 2 extra Energy attached to it (in addition to this attack's cost),
       heal all damage from all of your Pokémon. (Don't apply Weakness and Resistance
-      for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)
+      for Benched Pokémon.) (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: R
     value: x2
@@ -6166,7 +6166,7 @@ cards:
     text: Attach 5 basic Energy cards from your discard pile to your Pokémon in any
       way you like. If this Pokémon has at least 1 extra Energy attached to it (in
       addition to this attack's cost), your opponent's Active Pokémon is now Burned
-      and Confused. (You can’t use more than 1 GX attack in a game.)
+      and Confused. (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: W
     value: x2
@@ -6188,7 +6188,7 @@ cards:
   number: SM232
   types: [L]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC, POKEMON_GX]
+  subTypes: [BASIC, POKEMON_GX]
   hp: 160
   retreatCost: 1
   moves:
@@ -6196,7 +6196,7 @@ cards:
     name: Agility
     damage: '20'
     text: Flip a coin. If heads, prevent all effects of attacks, including damage,
-      done to this Pokémon during your opponent’s next turn.
+      done to this Pokémon during your opponent''s next turn.
   - cost: [L, L, C]
     name: Volt Tackle
     damage: '150'
@@ -6204,7 +6204,7 @@ cards:
   - cost: [L, L, C]
     name: Tail Break GX
     damage: '100'
-    text: Your opponent’s Active Pokémon is now Paralyzed. (You can’t use more than
+    text: Your opponent''s Active Pokémon is now Paralyzed. (You can''t use more than
       1 GX attack in a game.)
   weaknesses:
   - type: F
@@ -6237,7 +6237,7 @@ cards:
     damage: '100'
   - cost: [C]
     name: Joy Maker GX
-    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+    text: Put 3 cards from your discard pile into your hand. (You can''t use more than
       1 GX attack in a game.)
   weaknesses:
   - type: F
@@ -6251,7 +6251,7 @@ cards:
   number: SM234
   types: [L]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 60
   retreatCost: 1
   moves:
@@ -6276,7 +6276,7 @@ cards:
   number: SM235
   types: [C]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 60
   retreatCost: 1
   moves:
@@ -6326,7 +6326,7 @@ cards:
   number: SM237
   types: [G]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, STAGE1]
+  subTypes: [EVOLUTION, STAGE1]
   evolvesFrom: Eevee
   hp: 110
   retreatCost: 2
@@ -6349,7 +6349,7 @@ cards:
   number: SM238
   types: [W]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, STAGE1]
+  subTypes: [EVOLUTION, STAGE1]
   evolvesFrom: Eevee
   hp: 110
   retreatCost: 2
@@ -6376,24 +6376,24 @@ cards:
   number: SM239
   types: [F]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, POKEMON_GX, STAGE2]
+  subTypes: [EVOLUTION, POKEMON_GX, STAGE2]
   evolvesFrom: Tirtouga
   hp: 250
   retreatCost: 4
   abilities:
   - type: Ability
     name: High Density Armor
-    text: If this Pokémon has full HP, it takes 90 less damage from your opponent’s
+    text: If this Pokémon has full HP, it takes 90 less damage from your opponent''s
       attacks (after applying Weakness and Resistance).
   moves:
   - cost: [F, C, C, C]
     damage: '160'
     name: Ground Crush
-    text: The Defending Pokémon can’t retreat during your opponent’s next turn.
+    text: The Defending Pokémon can''t retreat during your opponent''s next turn.
   - cost: [C]
     name: Stone Age GX
     text: Put any number of Pokémon that evolve from Unidentified Fossil from your
-      discard pile onto your Bench. (You can’t use more than 1 GX attack in a game.)
+      discard pile onto your Bench. (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: G
     value: x2
@@ -6418,7 +6418,7 @@ cards:
     name: Cross Division GX
     text: Put 10 damage counters on your opponent's Pokémon in any way you like. If
       this Pokémon has at least 3 extra Energy attached to it (in addition to this
-      attack's cost), put 20 damage counters on them instead. (You can’t use more
+      attack's cost), put 20 damage counters on them instead. (You can''t use more
       than 1 GX attack in a game.)
   weaknesses:
   - type: P
@@ -6438,14 +6438,14 @@ cards:
   - cost: [D, D, C]
     name: Black Lance
     damage: '150'
-    text: This attack does 60 damage to 1 of your opponent’s Benched Pokémon-GX or
-      Benched Pokémon-EX. (Don’t apply Weakness and Resistance for Benched Pokémon.)
+    text: This attack does 60 damage to 1 of your opponent''s Benched Pokémon-GX or
+      Benched Pokémon-EX. (Don''t apply Weakness and Resistance for Benched Pokémon.)
   - cost: [C]
     name: Dark Moon GX
-    text: Your opponent can’t play any Trainer cards from their hand during their
+    text: Your opponent can''t play any Trainer cards from their hand during their
       next turn. If this Pokémon has at least 5 extra [D] Energy attached to it (in
-      addition to this attack’s cost), your opponent's Active Pokémon is Knocked Out.
-      (You can’t use more than 1 GX attack in a game.)
+      addition to this attack''s cost), your opponent's Active Pokémon is Knocked Out.
+      (You can''t use more than 1 GX attack in a game.)
   weaknesses:
   - type: F
     value: x2
@@ -6476,7 +6476,7 @@ cards:
     damage: '100'
   - cost: [C]
     name: Joy Maker GX
-    text: Put 3 cards from your discard pile into your hand. (You can’t use more than
+    text: Put 3 cards from your discard pile into your hand. (You can''t use more than
       1 GX attack in a game.)
   weaknesses:
   - type: F
@@ -6490,7 +6490,7 @@ cards:
   number: SM243
   types: [C]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 150
   retreatCost: 4
   moves:
@@ -6500,7 +6500,29 @@ cards:
   - cost: [W, F, M, C, C]
     name: Regiblast
     damage: '180'
-    text: Discard the top card of your opponent’s deck.
+    text: Discard the top card of your opponent''s deck.
+  weaknesses:
+  - type: F
+    value: x2
+  rarity: Promo
+- id: 410-SM244
+  pioId: smp-SM244
+  enumId: AIPOM_SM244
+  name: Aipom
+  number: SM244
+  types: [C]
+  superType: POKEMON
+  subTypes: [BASIC]
+  hp: 60
+  retreatCost: 1
+  moves:
+  - cost: [C]
+    name: Yank Out
+    text: Discard random cards from your opponent''s hand until they have 5 cards in their hand.
+  - cost: [C, C]
+    name: Tail Smash
+    damage: '30'
+    text: Flip a coin. If tails, this attack does nothing.
   weaknesses:
   - type: F
     value: x2

--- a/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -354,7 +354,7 @@ cards:
   rarity: Promo
 - id: 429-17
   pioId: swsh-17
-  enumId: TOXTRICITY_V_SWSH16
+  enumId: TOXTRICITY_V_SWSH17
   name: Toxtricity V
   number: '17'
   types: [L]
@@ -373,6 +373,60 @@ cards:
   weaknesses:
   - type: F
     value: x2
+  rarity: Promo
+- id: 429-18
+  pioId: swsh-18
+  enumId: ZACIAN_V_SWSH18
+  name: Zacian V
+  number: '18'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: Intrepid Sword
+    text: Once during your turn, you may look at the top 3 cards of your deck and
+      attach any number of [M] Energy cards you find there to this Pokémon. Put the
+      other cards into your hand. If you use this Ability, your turn ends.
+  moves:
+  - cost: [M, M, M]
+    name: Brave Blade
+    damage: '230'
+    text: During your next turn, this Pokémon can't attack.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
+  rarity: Promo
+- id: 429-19
+  pioId: swsh-19
+  enumId: ZAMAZENTA_V_SWSH19
+  name: Zamazenta V
+  number: '19'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 230
+  retreatCost: 2
+  abilities:
+  - type: Ability
+    name: 'Dauntless Shield'
+    text: 'Prevent all damage done to this Pokémon by attacks from your opponent’s Pokémon VMAX.'
+  moves:
+  - cost: [M, M, C]
+    name: Assault Tackle
+    damage: '130'
+    text: Discard a Special Energy from your opponent's Active Pokémon.
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
+    value: '-30'
   rarity: Promo
 - id: 429-20
   pioId: swsh-20
@@ -618,6 +672,32 @@ cards:
     value: x2
   resistances:
   - type: F
+    value: '-30'
+  rarity: Promo
+- id: 429-30
+  pioId: swsh-30
+  enumId: COPPERAJAH_V_SWSH30
+  name: Copperajah V
+  number: '30'
+  types: [M]
+  superType: POKEMON
+  subTypes: [BASIC, POKEMON_V]
+  hp: 220
+  retreatCost: 4
+  moves:
+  - cost: [M, M, C]
+    name: Adamantine Press
+    damage: '90'
+    text: During your opponent’s next turn, this Pokémon takes 30 less damage from
+      attacks (after applying Weakness and Resistance).
+  - cost: [M, M, M, C]
+    name: Wrack Down
+    damage: '180'
+  weaknesses:
+  - type: R
+    value: x2
+  resistances:
+  - type: G
     value: '-30'
   rarity: Promo
 - id: 429-31

--- a/src/main/resources/cards/429-sword_shield_promos.yaml
+++ b/src/main/resources/cards/429-sword_shield_promos.yaml
@@ -12,7 +12,7 @@ cards:
   number: '1'
   types: [G]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 60
   retreatCost: 1
   moves:
@@ -30,7 +30,7 @@ cards:
   number: '2'
   types: [R]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 60
   retreatCost: 1
   moves:
@@ -49,7 +49,7 @@ cards:
   number: '3'
   types: [W]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 60
   retreatCost: 1
   moves:
@@ -68,7 +68,7 @@ cards:
   number: '4'
   types: [C]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V]
   hp: 180
   retreatCost: 2
   moves:
@@ -90,7 +90,7 @@ cards:
   number: '5'
   types: [C]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, VMAX]
+  subTypes: [EVOLUTION, VMAX]
   hp: 300
   retreatCost: 2
   moves:
@@ -209,7 +209,7 @@ cards:
   number: '10'
   types: [G]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 50
   retreatCost: 1
   moves:
@@ -227,7 +227,7 @@ cards:
   number: '11'
   types: [C]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 60
   retreatCost: 1
   moves:
@@ -248,7 +248,7 @@ cards:
   number: '12'
   types: [L]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 80
   retreatCost: 1
   moves:
@@ -267,7 +267,7 @@ cards:
   number: '13'
   types: [P]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 70
   retreatCost: 1
   moves:
@@ -359,7 +359,7 @@ cards:
   number: '17'
   types: [L]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC, POKEMON_V]
+  subTypes: [BASIC, POKEMON_V]
   hp: 210
   retreatCost: 2
   moves:
@@ -435,7 +435,7 @@ cards:
   number: '20'
   types: [L]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 70
   retreatCost: 1
   moves:
@@ -632,7 +632,7 @@ cards:
   number: '28'
   types: [M]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 130
   retreatCost: 2
   moves:
@@ -656,7 +656,7 @@ cards:
   number: '29'
   types: [C]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 130
   retreatCost: 2
   moves:
@@ -707,7 +707,7 @@ cards:
   number: '31'
   types: [L]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, BASIC]
+  subTypes: [BASIC]
   hp: 80
   retreatCost: 1
   moves:

--- a/src/main/resources/cards/430-sword_shield.yaml
+++ b/src/main/resources/cards/430-sword_shield.yaml
@@ -195,7 +195,7 @@ cards:
   - cost: [G, G, C]
     name: Giga Hammer
     damage: '200'
-    text: During your next turn, this Pokémon can''t use Giga Hammer.
+    text: During your next turn, this Pokémon can't use Giga Hammer.
   weaknesses:
   - type: R
     value: x2
@@ -330,7 +330,7 @@ cards:
   - cost: [G, G, G, C]
     name: Drum Beating
     damage: '180'
-    text: During your next turn, this Pokémon can''t use Drum Beating.
+    text: During your next turn, this Pokémon can't use Drum Beating.
   weaknesses:
   - type: R
     value: x2
@@ -386,7 +386,7 @@ cards:
   moves:
   - cost: [C]
     name: Reflect
-    text: During your opponent''s next turn, this Pokémon takes 40 less damage from
+    text: During your opponent's next turn, this Pokémon takes 40 less damage from
       attacks (after applying Weakness and Resistance).
   - cost: [G, C]
     name: Ram
@@ -1108,7 +1108,7 @@ cards:
   abilities:
   - type: Ability
     name: Poison Point
-    text: If this Pokémon is your Active Pokémon and is damaged by an opponent''s attack
+    text: If this Pokémon is your Active Pokémon and is damaged by an opponent's attack
       (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.
   moves:
   - cost: [C]
@@ -1339,7 +1339,7 @@ cards:
   - cost: [W, C, C, C]
     name: Jaw Lock
     damage: '130'
-    text: During your opponent''s next turn, the Defending Pokémon can''t retreat.
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
   weaknesses:
   - type: L
     value: x2
@@ -1571,7 +1571,7 @@ cards:
   - cost: [L, L, C]
     name: Thunderous Bolt
     damage: '200'
-    text: During your next turn, this Pokémon can''t attack.
+    text: During your next turn, this Pokémon can't attack.
   weaknesses:
   - type: F
     value: x2
@@ -1633,7 +1633,7 @@ cards:
   - cost: [C, C]
     name: Big Bite
     damage: '50'
-    text: During your opponent''s next turn, the Defending Pokémon can''t retreat.
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
   - cost: [L, C, C]
     name: Fighting Fangs
     damage: 90+
@@ -1661,7 +1661,7 @@ cards:
   - cost: [L, L, C]
     name: Electrodash
     damage: '160'
-    text: During your next turn, this Pokémon can''t attack.
+    text: During your next turn, this Pokémon can't attack.
   weaknesses:
   - type: F
     value: x2
@@ -1681,7 +1681,7 @@ cards:
     name: Shocking Needles
     damage: 30x
     text: Flip 4 coins. This attack does 30 damage for each heads. If at least 2 of
-      them are heads, your opponent''s Active Pokémon is now Paralyzed.
+      them are heads, your opponent's Active Pokémon is now Paralyzed.
   weaknesses:
   - type: F
     value: x2
@@ -1788,7 +1788,7 @@ cards:
   abilities:
   - type: Ability
     name: 'Pastel Veil'
-    text: 'Your Pokémon recover from all Special Conditions and can''t be affected by any Special Conditions.'
+    text: 'Your Pokémon recover from all Special Conditions and can't be affected by any Special Conditions.'
   moves:
   - cost: [P, C]
     name: Psychic
@@ -1896,7 +1896,7 @@ cards:
   - cost: [P, P]
     name: Shadow Bind
     damage: '70'
-    text: During your opponent''s next turn, the Defending Pokémon can''t retreat.
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
   weaknesses:
   - type: D
     value: x2
@@ -2198,7 +2198,7 @@ cards:
     name: Bedrock Shake
     damage: '120'
     text: This attack also does 60 damage to each Benched Pokémon that has any damage
-      counters on it (both yours and your opponent''s). (Don’t apply Weakness and Resistance
+      counters on it (both yours and your opponent's). (Don’t apply Weakness and Resistance
       for Benched Pokémon.)
   weaknesses:
   - type: G
@@ -2366,8 +2366,8 @@ cards:
   moves:
   - cost: [C]
     name: Sand Attack
-    text: During your opponent''s next turn, if the Defending Pokémon tries to attack,
-      your opponent flips a coin. If tails, that attack doesn''t happen.
+    text: During your opponent's next turn, if the Defending Pokémon tries to attack,
+      your opponent flips a coin. If tails, that attack doesn't happen.
   weaknesses:
   - type: G
     value: x2
@@ -2494,7 +2494,7 @@ cards:
   - cost: [F, F]
     name: Octolock
     text: Until this Grapploct leaves the Active Spot, the Defending Pokémon's attacks
-      cost [C][C] more, and the Defending Pokémon can''t retreat. This effect can''t
+      cost [C][C] more, and the Defending Pokémon can't retreat. This effect can't
       be applied more than once.
   - cost: [F, F, C]
     name: Tough Swing
@@ -2629,12 +2629,12 @@ cards:
   abilities:
   - type: Ability
     name: 'Untamed Shout'
-    text: 'When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may put 3 damage counters on 1 of your opponent''s Pokémon.'
+    text: 'When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may put 3 damage counters on 1 of your opponent's Pokémon.'
   moves:
   - cost: [D, C]
     name: Obstruct
     damage: '90'
-    text: During your opponent''s next turn, prevent all damage done to this Pokémon
+    text: During your opponent's next turn, prevent all damage done to this Pokémon
       by attacks from Basic Pokémon.
   weaknesses:
   - type: G
@@ -2835,7 +2835,7 @@ cards:
   abilities:
   - type: Ability
     name: 'Steely Spirit'
-    text: Your [M] Pokémon's attacks do 20 more damage to your opponent''s Active Pokémon
+    text: Your [M] Pokémon's attacks do 20 more damage to your opponent's Active Pokémon
       (before applying Weakness and Resistance).
   moves:
   - cost: [M, M, C]
@@ -2866,7 +2866,7 @@ cards:
   - cost: [M, C]
     name: Crunch
     damage: '40'
-    text: Discard an Energy from your opponent''s Active Pokémon.
+    text: Discard an Energy from your opponent's Active Pokémon.
   weaknesses:
   - type: R
     value: x2
@@ -3018,7 +3018,7 @@ cards:
   - cost: [M, C, C]
     name: Iron Wings
     damage: '130'
-    text: You may discard 2 Energy from this Pokémon. If you do, during your opponent''s
+    text: You may discard 2 Energy from this Pokémon. If you do, during your opponent's
       next turn, this Pokémon takes 100 less damage from attacks (after applying Weakness
       and Resistance).
   weaknesses:
@@ -3097,7 +3097,7 @@ cards:
   - cost: [M, M, M]
     name: Brave Blade
     damage: '230'
-    text: During your next turn, this Pokémon can''t attack.
+    text: During your next turn, this Pokémon can't attack.
   weaknesses:
   - type: R
     value: x2
@@ -3123,7 +3123,7 @@ cards:
   - cost: [M, M, C]
     name: Assault Tackle
     damage: '130'
-    text: Discard a Special Energy from your opponent''s Active Pokémon.
+    text: Discard a Special Energy from your opponent's Active Pokémon.
   weaknesses:
   - type: R
     value: x2
@@ -3237,7 +3237,7 @@ cards:
     damage: '40'
   - cost: [C, C, C]
     name: Carry Off
-    text: Choose 1 of your opponent''s Benched Pokémon. They shuffle that Pokémon and
+    text: Choose 1 of your opponent's Benched Pokémon. They shuffle that Pokémon and
       all attached cards into their deck. Then, shuffle this Pokémon and all attached
       cards into your deck.
   weaknesses:
@@ -3393,7 +3393,7 @@ cards:
   - cost: [C]
     name: Pluck
     damage: '20'
-    text: Before doing damage, discard all Pokémon Tools from your opponent''s Active
+    text: Before doing damage, discard all Pokémon Tools from your opponent's Active
       Pokémon.
   - cost: [C, C]
     name: Drill Peck
@@ -3532,7 +3532,7 @@ cards:
   superType: TRAINER
   subTypes: [ITEM]
   rarity: Uncommon
-  text: ['Flip a coin. If heads, discard an Energy from 1 of your opponent''s Pokémon.']
+  text: ['Flip a coin. If heads, discard an Energy from 1 of your opponent's Pokémon.']
 - id: 430-160
   pioId: swsh1-160
   enumId: ENERGY_RETRIEVAL_160
@@ -3820,7 +3820,7 @@ cards:
   - cost: [G, G, C]
     name: Giga Hammer
     damage: '200'
-    text: During your next turn, this Pokémon can''t use Giga Hammer.
+    text: During your next turn, this Pokémon can't use Giga Hammer.
   weaknesses:
   - type: R
     value: x2
@@ -3923,7 +3923,7 @@ cards:
   - cost: [P, P]
     name: Shadow Bind
     damage: '70'
-    text: During your opponent''s next turn, the Defending Pokémon can''t retreat.
+    text: During your opponent's next turn, the Defending Pokémon can't retreat.
   weaknesses:
   - type: D
     value: x2
@@ -4032,7 +4032,7 @@ cards:
   - cost: [M, M, M]
     name: Brave Blade
     damage: '230'
-    text: During your next turn, this Pokémon can''t attack.
+    text: During your next turn, this Pokémon can't attack.
   weaknesses:
   - type: R
     value: x2
@@ -4060,7 +4060,7 @@ cards:
   - cost: [M, M, C]
     name: Assault Tackle
     damage: '130'
-    text: Discard a Special Energy from your opponent''s Active Pokémon.
+    text: Discard a Special Energy from your opponent's Active Pokémon.
   weaknesses:
   - type: R
     value: x2
@@ -4328,7 +4328,7 @@ cards:
   - cost: [M, M, M]
     name: Brave Blade
     damage: '230'
-    text: During your next turn, this Pokémon can''t attack.
+    text: During your next turn, this Pokémon can't attack.
   weaknesses:
   - type: R
     value: x2
@@ -4356,7 +4356,7 @@ cards:
   - cost: [M, M, C]
     name: Assault Tackle
     damage: '130'
-    text: Discard a Special Energy from your opponent''s Active Pokémon.
+    text: Discard a Special Energy from your opponent's Active Pokémon.
   weaknesses:
   - type: R
     value: x2

--- a/src/main/resources/cards/430-sword_shield.yaml
+++ b/src/main/resources/cards/430-sword_shield.yaml
@@ -195,7 +195,7 @@ cards:
   - cost: [G, G, C]
     name: Giga Hammer
     damage: '200'
-    text: During your next turn, this Pokémon can't use Giga Hammer.
+    text: During your next turn, this Pokémon can''t use Giga Hammer.
   weaknesses:
   - type: R
     value: x2
@@ -330,7 +330,7 @@ cards:
   - cost: [G, G, G, C]
     name: Drum Beating
     damage: '180'
-    text: During your next turn, this Pokémon can't use Drum Beating.
+    text: During your next turn, this Pokémon can''t use Drum Beating.
   weaknesses:
   - type: R
     value: x2
@@ -386,7 +386,7 @@ cards:
   moves:
   - cost: [C]
     name: Reflect
-    text: During your opponent's next turn, this Pokémon takes 40 less damage from
+    text: During your opponent''s next turn, this Pokémon takes 40 less damage from
       attacks (after applying Weakness and Resistance).
   - cost: [G, C]
     name: Ram
@@ -1108,7 +1108,7 @@ cards:
   abilities:
   - type: Ability
     name: Poison Point
-    text: If this Pokémon is your Active Pokémon and is damaged by an opponent's attack
+    text: If this Pokémon is your Active Pokémon and is damaged by an opponent''s attack
       (even if this Pokémon is Knocked Out), the Attacking Pokémon is now Poisoned.
   moves:
   - cost: [C]
@@ -1339,7 +1339,7 @@ cards:
   - cost: [W, C, C, C]
     name: Jaw Lock
     damage: '130'
-    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+    text: During your opponent''s next turn, the Defending Pokémon can''t retreat.
   weaknesses:
   - type: L
     value: x2
@@ -1571,7 +1571,7 @@ cards:
   - cost: [L, L, C]
     name: Thunderous Bolt
     damage: '200'
-    text: During your next turn, this Pokémon can't attack.
+    text: During your next turn, this Pokémon can''t attack.
   weaknesses:
   - type: F
     value: x2
@@ -1633,7 +1633,7 @@ cards:
   - cost: [C, C]
     name: Big Bite
     damage: '50'
-    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+    text: During your opponent''s next turn, the Defending Pokémon can''t retreat.
   - cost: [L, C, C]
     name: Fighting Fangs
     damage: 90+
@@ -1661,7 +1661,7 @@ cards:
   - cost: [L, L, C]
     name: Electrodash
     damage: '160'
-    text: During your next turn, this Pokémon can't attack.
+    text: During your next turn, this Pokémon can''t attack.
   weaknesses:
   - type: F
     value: x2
@@ -1681,7 +1681,7 @@ cards:
     name: Shocking Needles
     damage: 30x
     text: Flip 4 coins. This attack does 30 damage for each heads. If at least 2 of
-      them are heads, your opponent's Active Pokémon is now Paralyzed.
+      them are heads, your opponent''s Active Pokémon is now Paralyzed.
   weaknesses:
   - type: F
     value: x2
@@ -1788,7 +1788,7 @@ cards:
   abilities:
   - type: Ability
     name: 'Pastel Veil'
-    text: 'Your Pokémon recover from all Special Conditions and can't be affected by any Special Conditions.'
+    text: 'Your Pokémon recover from all Special Conditions and can''t be affected by any Special Conditions.'
   moves:
   - cost: [P, C]
     name: Psychic
@@ -1896,7 +1896,7 @@ cards:
   - cost: [P, P]
     name: Shadow Bind
     damage: '70'
-    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+    text: During your opponent''s next turn, the Defending Pokémon can''t retreat.
   weaknesses:
   - type: D
     value: x2
@@ -2198,7 +2198,7 @@ cards:
     name: Bedrock Shake
     damage: '120'
     text: This attack also does 60 damage to each Benched Pokémon that has any damage
-      counters on it (both yours and your opponent's). (Don’t apply Weakness and Resistance
+      counters on it (both yours and your opponent''s). (Don’t apply Weakness and Resistance
       for Benched Pokémon.)
   weaknesses:
   - type: G
@@ -2366,8 +2366,8 @@ cards:
   moves:
   - cost: [C]
     name: Sand Attack
-    text: During your opponent's next turn, if the Defending Pokémon tries to attack,
-      your opponent flips a coin. If tails, that attack doesn't happen.
+    text: During your opponent''s next turn, if the Defending Pokémon tries to attack,
+      your opponent flips a coin. If tails, that attack doesn''t happen.
   weaknesses:
   - type: G
     value: x2
@@ -2494,7 +2494,7 @@ cards:
   - cost: [F, F]
     name: Octolock
     text: Until this Grapploct leaves the Active Spot, the Defending Pokémon's attacks
-      cost [C][C] more, and the Defending Pokémon can't retreat. This effect can't
+      cost [C][C] more, and the Defending Pokémon can''t retreat. This effect can''t
       be applied more than once.
   - cost: [F, F, C]
     name: Tough Swing
@@ -2629,12 +2629,12 @@ cards:
   abilities:
   - type: Ability
     name: 'Untamed Shout'
-    text: 'When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may put 3 damage counters on 1 of your opponent's Pokémon.'
+    text: 'When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may put 3 damage counters on 1 of your opponent''s Pokémon.'
   moves:
   - cost: [D, C]
     name: Obstruct
     damage: '90'
-    text: During your opponent's next turn, prevent all damage done to this Pokémon
+    text: During your opponent''s next turn, prevent all damage done to this Pokémon
       by attacks from Basic Pokémon.
   weaknesses:
   - type: G
@@ -2835,7 +2835,7 @@ cards:
   abilities:
   - type: Ability
     name: 'Steely Spirit'
-    text: Your [M] Pokémon's attacks do 20 more damage to your opponent's Active Pokémon
+    text: Your [M] Pokémon's attacks do 20 more damage to your opponent''s Active Pokémon
       (before applying Weakness and Resistance).
   moves:
   - cost: [M, M, C]
@@ -2866,7 +2866,7 @@ cards:
   - cost: [M, C]
     name: Crunch
     damage: '40'
-    text: Discard an Energy from your opponent's Active Pokémon.
+    text: Discard an Energy from your opponent''s Active Pokémon.
   weaknesses:
   - type: R
     value: x2
@@ -3018,7 +3018,7 @@ cards:
   - cost: [M, C, C]
     name: Iron Wings
     damage: '130'
-    text: You may discard 2 Energy from this Pokémon. If you do, during your opponent's
+    text: You may discard 2 Energy from this Pokémon. If you do, during your opponent''s
       next turn, this Pokémon takes 100 less damage from attacks (after applying Weakness
       and Resistance).
   weaknesses:
@@ -3097,7 +3097,7 @@ cards:
   - cost: [M, M, M]
     name: Brave Blade
     damage: '230'
-    text: During your next turn, this Pokémon can't attack.
+    text: During your next turn, this Pokémon can''t attack.
   weaknesses:
   - type: R
     value: x2
@@ -3123,7 +3123,7 @@ cards:
   - cost: [M, M, C]
     name: Assault Tackle
     damage: '130'
-    text: Discard a Special Energy from your opponent's Active Pokémon.
+    text: Discard a Special Energy from your opponent''s Active Pokémon.
   weaknesses:
   - type: R
     value: x2
@@ -3237,7 +3237,7 @@ cards:
     damage: '40'
   - cost: [C, C, C]
     name: Carry Off
-    text: Choose 1 of your opponent's Benched Pokémon. They shuffle that Pokémon and
+    text: Choose 1 of your opponent''s Benched Pokémon. They shuffle that Pokémon and
       all attached cards into their deck. Then, shuffle this Pokémon and all attached
       cards into your deck.
   weaknesses:
@@ -3393,7 +3393,7 @@ cards:
   - cost: [C]
     name: Pluck
     damage: '20'
-    text: Before doing damage, discard all Pokémon Tools from your opponent's Active
+    text: Before doing damage, discard all Pokémon Tools from your opponent''s Active
       Pokémon.
   - cost: [C, C]
     name: Drill Peck
@@ -3532,7 +3532,7 @@ cards:
   superType: TRAINER
   subTypes: [ITEM]
   rarity: Uncommon
-  text: ['Flip a coin. If heads, discard an Energy from 1 of your opponent's Pokémon.']
+  text: ['Flip a coin. If heads, discard an Energy from 1 of your opponent''s Pokémon.']
 - id: 430-160
   pioId: swsh1-160
   enumId: ENERGY_RETRIEVAL_160
@@ -3820,7 +3820,7 @@ cards:
   - cost: [G, G, C]
     name: Giga Hammer
     damage: '200'
-    text: During your next turn, this Pokémon can't use Giga Hammer.
+    text: During your next turn, this Pokémon can''t use Giga Hammer.
   weaknesses:
   - type: R
     value: x2
@@ -3923,7 +3923,7 @@ cards:
   - cost: [P, P]
     name: Shadow Bind
     damage: '70'
-    text: During your opponent's next turn, the Defending Pokémon can't retreat.
+    text: During your opponent''s next turn, the Defending Pokémon can''t retreat.
   weaknesses:
   - type: D
     value: x2
@@ -4032,7 +4032,7 @@ cards:
   - cost: [M, M, M]
     name: Brave Blade
     damage: '230'
-    text: During your next turn, this Pokémon can't attack.
+    text: During your next turn, this Pokémon can''t attack.
   weaknesses:
   - type: R
     value: x2
@@ -4060,7 +4060,7 @@ cards:
   - cost: [M, M, C]
     name: Assault Tackle
     damage: '130'
-    text: Discard a Special Energy from your opponent's Active Pokémon.
+    text: Discard a Special Energy from your opponent''s Active Pokémon.
   weaknesses:
   - type: R
     value: x2
@@ -4328,7 +4328,7 @@ cards:
   - cost: [M, M, M]
     name: Brave Blade
     damage: '230'
-    text: During your next turn, this Pokémon can't attack.
+    text: During your next turn, this Pokémon can''t attack.
   weaknesses:
   - type: R
     value: x2
@@ -4356,7 +4356,7 @@ cards:
   - cost: [M, M, C]
     name: Assault Tackle
     damage: '130'
-    text: Discard a Special Energy from your opponent's Active Pokémon.
+    text: Discard a Special Energy from your opponent''s Active Pokémon.
   weaknesses:
   - type: R
     value: x2

--- a/src/main/resources/cards/431-rebel-clash.yaml
+++ b/src/main/resources/cards/431-rebel-clash.yaml
@@ -3798,7 +3798,7 @@ cards:
   superType: ENERGY
   subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text: ['As long as this card is attached to a Pokémon that isn't a Pokémon V or
+  text: ['As long as this card is attached to a Pokémon that isn''t a Pokémon V or
       a Pokémon-GX, it provides [C][C] Energy. ', 'If this card is attached to a Pokémon
       V or a Pokémon-GX, it provides [C] Energy instead.']
 - id: 431-175
@@ -4536,7 +4536,7 @@ cards:
   superType: ENERGY
   subTypes: [SPECIAL_ENERGY]
   rarity: Secret
-  text: ['As long as this card is attached to a Pokémon that isn't a Pokémon V or
+  text: ['As long as this card is attached to a Pokémon that isn''t a Pokémon V or
       a Pokémon-GX, it provides [C][C] Energy. ', 'If this card is attached to a Pokémon
       V or a Pokémon-GX, it provides [C] Energy instead.']
   copyOf: 431-174

--- a/src/main/resources/cards/431-rebel-clash.yaml
+++ b/src/main/resources/cards/431-rebel-clash.yaml
@@ -850,7 +850,7 @@ cards:
   number: '38'
   types: [W]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, STAGE1]
+  subTypes: [EVOLUTION, STAGE1]
   evolvesFrom: Galarian Mr. Mime
   hp: 110
   retreatCost: 1
@@ -2198,7 +2198,7 @@ cards:
   number: '95'
   types: [F]
   superType: POKEMON
-  subTypes: [NOT_IMPLEMENTED, EVOLUTION, STAGE1]
+  subTypes: [EVOLUTION, STAGE1]
   evolvesFrom: Galarian Farfetch'd
   hp: 130
   retreatCost: 2
@@ -3798,7 +3798,7 @@ cards:
   superType: ENERGY
   subTypes: [SPECIAL_ENERGY]
   rarity: Uncommon
-  text: ['As long as this card is attached to a Pokémon that isn''t a Pokémon V or
+  text: ['As long as this card is attached to a Pokémon that isn't a Pokémon V or
       a Pokémon-GX, it provides [C][C] Energy. ', 'If this card is attached to a Pokémon
       V or a Pokémon-GX, it provides [C] Energy instead.']
 - id: 431-175
@@ -4536,7 +4536,7 @@ cards:
   superType: ENERGY
   subTypes: [SPECIAL_ENERGY]
   rarity: Secret
-  text: ['As long as this card is attached to a Pokémon that isn''t a Pokémon V or
+  text: ['As long as this card is attached to a Pokémon that isn't a Pokémon V or
       a Pokémon-GX, it provides [C][C] Energy. ', 'If this card is attached to a Pokémon
       V or a Pokémon-GX, it provides [C] Energy instead.']
   copyOf: 431-174


### PR DESCRIPTION
* ~~Cleans up some random apostrophes that were left all up next to each other. Weirdly, this doesn't seem to affect card text on pages, but it looks ugly internally, so I cleaned this up.~~ _(this is an intentional behavior on carddb, woops)_
* Added ZACIAN_V_SWSH18, ZAMAZENTA_V_SWSH19, and COPPERAJAH_V_30 to Sword and Shield Promos. (they release on 5/22 but are just alt. arts anyway. still need to get their scans)
* Unmarked Galarian Mr. Rime and Galarian Sirfetch'd as unimplemented as they are now fixed.