### PR TITLE
Update all Base-Gym Poke-Powers and Bodies + other updates

### DIFF
--- a/src/main/resources/cards/181-pokemod_base_set.yaml
+++ b/src/main/resources/cards/181-pokemod_base_set.yaml
@@ -19,7 +19,7 @@ cards:
   hp: 80
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Damage Swap
     text: As often as you like during your turn (before your attack), you may move
       1 damage counter from 1 of your Pokémon to another as long as you don't Knock
@@ -48,7 +48,7 @@ cards:
   hp: 100
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Rain Dance
     text: As often as you like during your turn (before your attack), you may attach
       1 [W] Energy Card to 1 of your [W] Pokémon (excluding Pokémon-ex). (This doesn't
@@ -108,7 +108,7 @@ cards:
   hp: 120
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Energy Burn
     text: As often as you like during your turn (before your attack), you may turn
       all Basic Energy attached to Charizard into [R] Energy for the rest of the turn.
@@ -220,7 +220,7 @@ cards:
   hp: 100
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Strikes Back
     text: Whenever your opponent's attack damages Machamp (even if Machamp is Knoced
       Out), this power does 10 damage to the attacking Pokémon. (Don't apply Weakness
@@ -413,7 +413,7 @@ cards:
   hp: 100
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Energy Trans
     text: As often as you like during your turn (before your attack), you may take
       1 [G] Energy card attached to 1 of your Pokémon and attach it to a different
@@ -575,7 +575,7 @@ cards:
   hp: 80
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Buzzap
     text: At any time during your turn (before your attack) you may Knock Out Electrode
       and attach it to 1 of your other Pokémon. If you do, choose a type of Energy.
@@ -2269,7 +2269,7 @@ cards:
   hp: 100
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Rain Dance
     text: As often as you like during your turn (before your attack), you may attach
       1 [W] Energy Card to 1 of your [W] Pokémon (excluding Pokémon-ex). (This doesn't
@@ -2300,7 +2300,7 @@ cards:
   hp: 120
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Energy Burn
     text: As often as you like during your turn (before your attack), you may turn
       all Basic Energy attached to Charizard into [R] Energy for the rest of the turn.
@@ -2331,7 +2331,7 @@ cards:
   hp: 100
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Energy Trans
     text: As often as you like during your turn (before your attack), you may take
       1 [G] Energy card attached to 1 of your Pokémon and attach it to a different

--- a/src/main/resources/cards/182-pokemod_jungle.yaml
+++ b/src/main/resources/cards/182-pokemod_jungle.yaml
@@ -157,7 +157,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Invisible Wall
     text: Whenever an attack (including your own) does 30 or more damage to Mr. Mime
       (after applying Weakness and Resistance), prevent that damage. (Any other effects
@@ -212,7 +212,7 @@ cards:
   hp: 80
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Quick Search
     text: Once during your turn (before your attack), you may choose 1 card from your
       deck and put it into your hand. If you do, put 2 damage counters on Pidgeot.
@@ -297,7 +297,7 @@ cards:
   hp: 90
   retreatCost: 4
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Thick Skinned
     text: Snorlax can't become affected by a Special Condition. This power
       can't be used if Snorlax is already affected by a Special Condition.
@@ -356,7 +356,7 @@ cards:
   hp: 70
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Shift
     text: Once during your turn (before your attack), you may change the type of Venomoth
       to the type of any other Pokémon in play other than [C], [D] or [M]. This power can't be
@@ -414,7 +414,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Heal
     text: Once during your turn (before your attack), you may flip a coin. If heads,
       remove 1 damage counter from 1 of your Pokémon. This power can't be used if
@@ -609,7 +609,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Invisible Wall
     text: Whenever an attack (including your own) does 30 or more damage to Mr. Mime
       (after applying Weakness and Resistance), prevent that damage. (Any other effects
@@ -664,7 +664,7 @@ cards:
   hp: 80
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Quick Search
     text: Once during your turn (before your attack), you may choose 1 card from your
       deck and put it into your hand. If you do, put 2 damage counters on Pidgeot.
@@ -749,7 +749,7 @@ cards:
   hp: 90
   retreatCost: 4
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Thick Skinned
     text: Snorlax can't become Asleep, Confused, Paralyzed, or Poisoned. This power
       can't be used if Snorlax is already Asleep, Confused, or Paralyzed.
@@ -808,7 +808,7 @@ cards:
   hp: 70
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Shift
     text: Once during your turn (before your attack), you may change the type of Venomoth
       to the type of any other Pokémon in play other than [C]. This power can't be
@@ -866,7 +866,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Heal
     text: Once during your turn (before your attack), you may flip a coin. If heads,
       remove 1 damage counter from 1 of your Pokémon. This power can't be used if
@@ -956,7 +956,7 @@ cards:
   hp: 70
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Retreat Aid
     text: As long as Dodrio is Benched, pay 1 [C] less to retreat your Active Pokémon.
   moves:
@@ -1532,7 +1532,7 @@ cards:
   hp: 50
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Peek
     text: 'Once during your turn (before your attack), you may look at one of the
       following: the top card of either player''s deck, a random card from your opponent''s
@@ -1910,7 +1910,7 @@ cards:
   hp: 90
   retreatCost: 4
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Thick Skinned
     text: Snorlax can't become affected by a Special Condition. This power
       can't be used if Snorlax is already affected by a Special Condition.

--- a/src/main/resources/cards/183-pokemod_fossil.yaml
+++ b/src/main/resources/cards/183-pokemod_fossil.yaml
@@ -19,7 +19,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Prehistoric Power
     text: No more Evolution cards can be played. This power stops working while Aerodactyl
         is affected by a Special Condition.
@@ -77,11 +77,11 @@ cards:
   hp: 50
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Transform
     text: If Ditto is your Active Pokémon, treat it as if it were the same card as
         the Defending Pokémon, including type, Hit Points, Weakness, and so on, except
-        Ditto can't evolve, always has this Pokémon Power, and you may treat any Energy
+        Ditto can't evolve, always has this Poké-Power, and you may treat any Energy
         attached to Ditto as Energy of any type. Ditto isn't a copy of any other Pokémon
         while Ditto is affected by a Special Condition.
   weaknesses:
@@ -105,7 +105,7 @@ cards:
   hp: 100
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Step In
     text: Once during your turn (before your attack) if Dragonite is on your Bench,
         you may switch it with your Active Pokémon.
@@ -132,7 +132,7 @@ cards:
   hp: 80
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Curse
     text: Once during your turn (before your attack), you may move 1 damage counter
         from 1 of your opponent's Pokémon to another (even if it would Knock Out the
@@ -166,7 +166,7 @@ cards:
   hp: 60
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Transparency
     text: Whenever an attack does anything to Haunter, flip a coin. If heads, prevent
         all effects of that attack, including damage, done to Haunter. This power stops
@@ -361,9 +361,9 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Toxic Gas
-    text: As long as this Pokémon has any Energy cards attached to it, ignore all Pokémon Powers
+    text: As long as this Pokémon has any Energy cards attached to it, ignore all Poké-Powers
         other than Toxic Gases. This power stops working while Muk is affected by
         a Special Condition.
   moves:
@@ -435,7 +435,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Prehistoric Power
     text: No more Evolution cards can be played. This power stops working while Aerodactyl
         is affected by a Special Condition.
@@ -493,11 +493,11 @@ cards:
   hp: 50
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Transform
     text: If Ditto is your Active Pokémon, treat it as if it were the same card as
         the Defending Pokémon, including type, Hit Points, Weakness, and so on, except
-        Ditto can't evolve, always has this Pokémon Power, and you may treat any Energy
+        Ditto can't evolve, always has this Poké-Power, and you may treat any Energy
         attached to Ditto as Energy of any type. Ditto isn't a copy of any other Pokémon
         while Ditto is affected by a Special Condition.
   weaknesses:
@@ -521,7 +521,7 @@ cards:
   hp: 100
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Step In
     text: Once during your turn (before you attack) if Dragonite is on your Bench,
         you may switch it with your Active Pokémon.
@@ -548,7 +548,7 @@ cards:
   hp: 80
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Curse
     text: Once during your turn (before your attack), you may move 1 damage counter
         from 1 of your opponent's Pokémon to another (even if it would Knock Out the
@@ -582,7 +582,7 @@ cards:
   hp: 60
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Transparency
     text: Whenever an attack does anything to Haunter, flip a coin. If heads, prevent
         all effects of that attack, including damage, done to Haunter. This power stops
@@ -777,9 +777,9 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Toxic Gas
-    text: As long as this Pokémon has any Energy cards attached to it, ignore all Pokémon Powers
+    text: As long as this Pokémon has any Energy cards attached to it, ignore all Poké-Powers
         other than Toxic Gases. This power stops working while Muk is affected by
         a Special Condition.
   moves:
@@ -1188,7 +1188,7 @@ cards:
   hp: 60
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Strange Behavior
     text: As often as you like during your turn (before your attack), you may move
         1 damage counter from 1 of your Pokémon to Slowbro as long as you don't Knock
@@ -1367,7 +1367,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Kabuto Armor
     text: Whenever an attack (even your own) does damage to Kabuto (after applying
         Weakness and Resistance), that attack only does half the damage to Kabuto (rounded
@@ -1424,7 +1424,7 @@ cards:
   hp: 50
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Clairvoyance
     text: Your opponent plays with his or her hand face up. This power stops working
         while Omanyte is affected by a Special Condition.
@@ -1533,7 +1533,7 @@ cards:
   hp: 40
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Cowardice
     text: At any time during your turn (before your attack), you may return Tentacool
         to your hand. (Discard all cards attached to Tentacool.) This power can't be
@@ -1645,7 +1645,7 @@ cards:
   subTypes: [POKEMON_TOOL]
   rarity: Uncommon
   text: ['As long as the Pokémon Crystal Guard is attached to (excluding Pokémon-ex) is 1 of
-    your Benched Pokémon, ignore all effects of attacks and Pokémon Powers (including damage)
+    your Benched Pokémon, ignore all effects of attacks and Poké-Powers (including damage)
     done to that Pokémon by your opponent''s Pokémon']
   artist: Hikaru Koike
 - id: 183-64
@@ -1719,7 +1719,7 @@ cards:
   superType: TRAINER
   subTypes: [STADIUM]
   rarity: Rare
-  text: ['Each Special Energy that provides 2 or more Energy (both yours and your opponent''s) now provides on 1 [C] Energy. This isn''t affected by any Pokémon Powers.']
+  text: ['Each Special Energy that provides 2 or more Energy (both yours and your opponent''s) now provides on 1 [C] Energy. This isn''t affected by any Poké-Powers.']
   artist: Ken Sugimori
 - id: 183-71
   pioId: pkmod3-71
@@ -1826,7 +1826,7 @@ cards:
   hp: 100
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Step In
     text: Once during your turn (before your attack) if Dragonite is on your Bench,
         you may switch it with your Active Pokémon.
@@ -1853,7 +1853,7 @@ cards:
   hp: 80
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Curse
     text: Once during your turn (before your attack), you may move 1 damage counter
         from 1 of your opponent''s Pokémon to another (even if it would Knock Out the
@@ -1885,7 +1885,7 @@ cards:
   hp: 90
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Phoenix Rise
     text: Once during your turn (before your attack), if this Pokémon is in your discard pile, you may flip a coin. If heads, put this Pokémon onto your Bench. Then, you may flip 3 more coins. For each of those coins that are heads, attach a different type of basic Energy card from your discard pile to this Pokémon.
   moves:

--- a/src/main/resources/cards/184-pokemod_base_set_2.yaml
+++ b/src/main/resources/cards/184-pokemod_base_set_2.yaml
@@ -18,7 +18,7 @@ cards:
   hp: 80
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Damage Swap
     text: As often as you like during your turn (before your attack), you may move
       1 damage counter from 1 of your Pokémon to another as long as you don't Knock
@@ -47,7 +47,7 @@ cards:
   hp: 100
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Rain Dance
     text: As often as you like during your turn (before your attack), you may attach
       1 [W] Energy Card to 1 of your [W] Pokémon (excluding Pokémon-ex). (This doesn't
@@ -107,7 +107,7 @@ cards:
   hp: 120
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Energy Burn
     text: As often as you like during your turn (before your attack), you may turn
       all Basic Energy attached to Charizard into [R] Energy for the rest of the turn.
@@ -384,7 +384,7 @@ cards:
   hp: 80
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Quick Search
     text: Once during your turn (before your attack), you may choose 1 card from your
       deck and put it into your hand. If you do, put 2 damage counters on Pidgeot.
@@ -501,7 +501,7 @@ cards:
   hp: 100
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Energy Trans
     text: As often as you like during your turn (before your attack), you may take
       1 [G] Energy card attached to 1 of your Pokémon and attach it to a different
@@ -690,7 +690,7 @@ cards:
   hp: 80
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Buzzap
     text: At any time during your turn (before your attack) you may Knock Out Electrode
       and attach it to 1 of your other Pokémon. If you do, chose a type of Energy.
@@ -746,7 +746,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Invisible Wall
     text: Whenever an attack (including your own) does 30 or more damage to Mr. Mime
       (after applying Weakness and Resistance), prevent that damage. (Any other effects
@@ -832,7 +832,7 @@ cards:
   hp: 90
   retreatCost: 4
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Thick Skinned
     text: Snorlax can't become Asleep, Confused, Paralyzed, or Poisoned. This power
       can't be used if Snorlax is already Asleep, Confused, or Paralyzed.
@@ -862,7 +862,7 @@ cards:
   hp: 70
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Shift
     text: Once during your turn (before your attack), you may change the type of Venomoth
       to the type of any other Pokémon in play other than [C]. This power can't be
@@ -1030,7 +1030,7 @@ cards:
   hp: 70
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Retreat Aid
     text: As long as Dodrio is Benched, pay 1 [C] less to retreat your Active Pokémon.
   moves:

--- a/src/main/resources/cards/185-pokemod_team_rocket.yaml
+++ b/src/main/resources/cards/185-pokemod_team_rocket.yaml
@@ -52,7 +52,7 @@ cards:
     text: Choose 1 of your opponent's Pokémon. This attack does 20 damage to that
       Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects
       that would happen after applying Weakness and Resistance still happen.) If that
-      Pokémon has a Pokémon Power, that power stops working until the end of your
+      Pokémon has a Poké-Power, that power stops working until the end of your
       opponent's next turn.
   - cost: [G, G, C]
     name: Poison Vapor
@@ -138,7 +138,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Summon Minions
     text: When you play Dark Dragonite from your hand, search your deck for up to
       2 Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.
@@ -164,7 +164,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Sinkhole
     text: Whenever your opponent's Active Pokémon retreats, your opponent flips a
       coin. If tails, this power does 20 damage to that Pokémon. (Don't apply Weakness
@@ -198,7 +198,7 @@ cards:
   hp: 50
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Sneak Attack
     text: When you play Dark Golbat from your hand, you may choose 1 of your opponent's
       Pokémon. If you do, Dark Golbat does 10 damage to that Pokémon. Apply Weakness
@@ -230,7 +230,7 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Final Beam
     text: When Dark Gyarados is Knocked Out by an attack, flip a coin. If heads, this
       power does 20 damage for each [W] Energy attached to Dark Gyarados to the Pokémon
@@ -346,7 +346,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Reel In
     text: When you play Dark Slowbro from your hand, choose up to 3 Basic Pokémon
       and/or Evolution cards from your discard pile and put them into your hand.
@@ -372,7 +372,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Hay Fever
     text: No Trainer cards can be played (except Supporter cards). This power stops working if Dark Vilplume has any Trainer cards attached to it, or while Dark Vileplume is Asleep, Confused, or Paralyzed.
   moves:
@@ -501,7 +501,7 @@ cards:
     text: Choose 1 of your opponent's Pokémon. This attack does 20 damage to that
       Pokémon. Don't apply Weakness and Resistance for this attack. (Any other effects
       that would happen after applying Weakness and Resistance still happen.) If that
-      Pokémon has a Pokémon Power, that power stops working until the end of your
+      Pokémon has a Poké-Power, that power stops working until the end of your
       opponent's next turn.
   - cost: [G, G, C]
     name: Poison Vapor
@@ -587,7 +587,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Summon Minions
     text: When you play Dark Dragonite from your hand, search your deck for up to
       2 Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.
@@ -613,7 +613,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Sinkhole
     text: Whenever your opponent's Active Pokémon retreats, your opponent flips a
       coin. If tails, this power does 20 damage to that Pokémon. (Don't apply Weakness
@@ -647,7 +647,7 @@ cards:
   hp: 50
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Sneak Attack
     text: When you play Dark Golbat from your hand, you may choose 1 of your opponent's
       Pokémon. If you do, Dark Golbat does 10 damage to that Pokémon. Apply Weakness
@@ -680,7 +680,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Final Beam
     text: When Dark Gyarados is Knocked Out by an attack, flip a coin. If heads, this
       power does 20 damage for each [W] Energy attached to Dark Gyarados to the Pokémon
@@ -796,7 +796,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Reel In
     text: When you play Dark Slowbro from your hand, choose up to 3 Basic Pokémon
       and/or Evolution cards from your discard pile and put them into your hand.
@@ -822,7 +822,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Hay Fever
     text: No Trainer cards can be played (except Supporter cards). This power stops working if Dark Vilplume has any Trainer cards attached to it, or while Dark Vileplume is Asleep, Confused, or Paralyzed.
   moves:
@@ -908,7 +908,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Evolutionary Light
     text: Once during your turn (before your attack), you may search your deck for
       an Evolution card. Show it to your opponent and put it into your hand. Shuffle
@@ -994,7 +994,7 @@ cards:
   hp: 50
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Pollen Stench
     text: Once during your turn (before your attack), you may flip a coin. If heads,
       the Defending Pokémon is now Confused; if tails, your Active Pokémon is now
@@ -1076,7 +1076,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Matter Exchange
     text: Once during your turn (before your attack), you may discard a card from
       your hand in order to draw a card. This power can't be used if Dark Kadabra
@@ -1136,7 +1136,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Sticky Goo
     text: As long as Dark Muk is your Active Pokémon, your opponent pays 2 more to
       retreat his or her Active Pokémon. This power stops working while Dark Muk is
@@ -1194,7 +1194,7 @@ cards:
   hp: 60
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Frenzy
     text: If Dark Primeape does any damage while it's Confused (even to itself), it
       does 30 more damage.
@@ -1379,7 +1379,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Gather Fire
     text: Once during your turn (before your attack), you may take 1 [R] Energy card
       attached to 1 of your other Pokémon and attach it to Charmander. This power
@@ -1485,7 +1485,7 @@ cards:
   hp: 50
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Long-Distance Hypnosis
     text: Distance Hypnosis - Once during your turn (before your attack), you may
       flip a coin. If heads, the Defending Pokémon is now Asleep; if tails, your Active
@@ -1793,7 +1793,7 @@ cards:
   hp: 40
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Trickery
     text: Once during your turn (before your attack), you may switch 1 of your Prizes
       with the top card of your deck. This power can't be used if Rattata is Asleep,
@@ -2087,7 +2087,7 @@ cards:
   superType: ENERGY
   subTypes: [SPECIAL_ENERGY]
   rarity: Rare
-  text: ['Boost Energy provides [C] Energy. While in play, if you have more Prize cards left than your opponent, Boost Energy provides [C, C, C]. If the Pokémon Boost Energy is attached to has a Pokémon Power, or has any other Special Energy cards attached to it (at any time), discard Boost Energy. If the Pokémon Boost Energy is attached to is a Pokémon-ex, discard Boost Energy']
+  text: ['Boost Energy provides [C] Energy. While in play, if you have more Prize cards left than your opponent, Boost Energy provides [C, C, C]. If the Pokémon Boost Energy is attached to has a Poké-Power, or has any other Special Energy cards attached to it (at any time), discard Boost Energy. If the Pokémon Boost Energy is attached to is a Pokémon-ex, discard Boost Energy']
   energy:
   - [C]
   artist: Unknown
@@ -2266,7 +2266,7 @@ cards:
   hp: 30
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Time Travel
     text: Whenever an attack does anything to Celebi, flip a coin. If heads, prevent all effects of that attack, including damage done
         to Celebi. This power stops working if Celebi is Asleep, Confused, Paralyzed or Poisoned.]
@@ -2335,7 +2335,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Summon Minions
     text: When you play Dark Dragonite from your hand, search your deck for up to
       2 Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.

--- a/src/main/resources/cards/186-pokemod_gym_heroes.yaml
+++ b/src/main/resources/cards/186-pokemod_gym_heroes.yaml
@@ -41,7 +41,7 @@ cards:
   hp: 80
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Bench Guard
     text: As long as Brock's Rhydon is Benched, whenever 1 of your Benched Pokémon
       is damaged, you may do 10 of that damage to Brock's Rhydon instead. (If more
@@ -131,7 +131,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Pollen Defense
     text: If an attack does damage to Erika's Vileplume while it's your Active Pokémon
       (even if it's Knocked Out), flip a coin. If heads, your opponent's Active Pokémon
@@ -223,7 +223,7 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Energy Charge
     text: As often as you like during your turn (before your attack), if Lt. Surge's
       Magneton is your Active Pokémon, you may take 1 [L] Energy card attached to
@@ -279,7 +279,7 @@ cards:
   hp: 70
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Flee
     text: If an attack does damage to Misty's Tentacruel while it's your Active Pokémon,
       you may switch it with 1 of your Benched Pokémon, which prevents all other effects
@@ -335,7 +335,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Rebirth
     text: When Rocket's Moltres is Knocked Out, you may return it to your hand after
       discarding it. This power can't be used if Rocket's Moltres is Asleep, Confused,
@@ -659,7 +659,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Fragrance Trap
     text: Once during your turn (before your attack), you may flip a coin. If heads,
       and if your opponent has any Benched Pokémon, choose 1 of them and switch it
@@ -742,9 +742,9 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Shell Armor
-    text: You may reduce all damage done by attacks to Misty's Cloyster by 10 (after
+    text: You may reduce all damage done by attacks to Misty's Cloyster by 20 (after
       applying Weakness and Resistance). (Any other effects of attacks still happen.)
       This power can't be used if Misty's Cloyster is Asleep, Confused, or Paralyzed.
   moves:
@@ -841,7 +841,7 @@ cards:
   hp: 90
   retreatCost: 4
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Restless Sleep
     text: If your opponent's attack does damage to Rocket's Snorlax and Rocket's Snorlax
       is already Asleep (even if it's Knocked Out), this power does 20 damage to the
@@ -1098,7 +1098,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Strange Barrier
     text: Whenever an attack by a Basic Pokémon (including your own) does 20 or more
       damage to Erika's Dratini (after applying Weakness and Resistance), reduce that
@@ -1239,7 +1239,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Photosynthesis
     text: All Energy cards attached to Erika's Oddish provide [G] Energy instead of
       their usual type. This power works even while Erika's Oddish is Asleep, Confused,
@@ -1713,7 +1713,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Natural Healing
     text: Once during your turn (before your attack), you may remove 1 damage counter
       from Blaine's Vulpix. This power can't be used if Blaine's Vulpix is Asleep,
@@ -2957,8 +2957,8 @@ cards:
   subTypes: []
   rarity: Uncommon
   text: [You may play this card during your opponent's turn. When any of your opponent's Pokémon uses an 
-    Pokémon Power, prevent all effects of that Pokémon Power until the end of your opponent's turn. 
-    (Playing this card counts as your opponent's Pokémon using their Pokémon Power). If you have 2 or less 
+    Poké-Power, prevent all effects of that Poké-Power until the end of your opponent's turn. 
+    (Playing this card counts as your opponent's Pokémon using their Poké-Power). If you have 2 or less 
     Pokémon in play, you cannot play this card.]
   artist: Ken Sugimori
 - id: 186-134

--- a/src/main/resources/cards/187-pokemod_gym_challenge.yaml
+++ b/src/main/resources/cards/187-pokemod_gym_challenge.yaml
@@ -76,12 +76,12 @@ cards:
   hp: 70
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Shapeshift
     text: Once during your turn (before your attack), you may attach an Evolution
       card (excluding Pokémon ex) from your hand to Brock's Ninetales. (This doesn't count as evolving 
       Brock's Ninetales.) Treat Brock's Ninetales as if it were that Pokémon instead. It can't
-      evolve, devolve, or use the Pokémon Power of that Pokémon. During your turn,
+      evolve, devolve, or use the Poké-Power/Body of that Pokémon. During your turn,
       you may discard the Evolution card attached to Brock's Ninetales. This power
       can't be used if Brock's Ninetales is Asleep, Confused, or Paralyzed. If Brock's
       Ninetales becomes Asleep, Confused, or Paralyzed, discard all Evolution cards
@@ -167,7 +167,7 @@ cards:
   hp: 100
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Fortitude
     text: If Giovanni's Machamp would be Knocked Out by an opponent's attack, flip
       a coin. If heads, Giovanni's Machamp is not Knocked Out and its remaining HP
@@ -224,7 +224,7 @@ cards:
   hp: 60
   retreatCost: 0
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Call the Boss
     text: When you play Giovanni's Persian from your hand, you may search your deck
       for the Trainer card named Giovanni, show it to your opponent, and put it into
@@ -370,7 +370,7 @@ cards:
   hp: 100
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Rebellion
     text: Whenever Misty's Gyarados attacks, flip 2 coins. If both of them are tails,
       that attack does nothing. Instead, shuffle Misty's Gyarados and all cards attached
@@ -454,7 +454,7 @@ cards:
   hp: 80
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Psylink
     text: Sabrina's Alakazam always has a copy of every attack your [P] Pokémon 
       in play have (excluding Pokémon ex) (including their Energy costs and anything else required in 
@@ -530,7 +530,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Healing Fire
     text: Whenever you attach a [R] Energy card from your hand to Blaine's Ninetales,
       remove 1 damage counter from it, if it has any. This power stops working while
@@ -670,7 +670,7 @@ cards:
   hp: 80
   retreatCost: 3
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Energy Drain
     text: If an opponent's attack does damage to Koga's Muk (even if Koga's Muk is
       Knocked Out), flip a coin. If heads and if it has any, choose 1 Energy card
@@ -926,7 +926,7 @@ cards:
   hp: 70
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Scram
     text: If Brock's Primeape ever has exactly 10 HP left, shuffle it and all cards
       attached to it into your deck. This power stops working while Brock's Primeape
@@ -1011,7 +1011,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Soak Up
     text: Once during your turn (before your attack), you may take up to 2 [G] Energy
       cards attached to your other Pokémon and attach them to Erika's Bellsprout.
@@ -1096,7 +1096,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Relaxing Scent
     text: As long as Erika's Ivysaur is your Active Pokémon, whenever an attack (even
       your own) does damage to any Pokémon (after applying Weakness and Resistance),
@@ -1267,7 +1267,7 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Power
     name: Emerge
     text: Once during your turn (before your attack), you may flip a coin. If heads,
       search your deck for an Evolution card named Koga's Beedrill and put it on Koga's
@@ -1412,7 +1412,7 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Shock Blast
     text: If Lt. Surge's Electrode is your Active Pokémon and gets damaged (even if
       it's Knocked Out), flip a coin. If tails, this power does 20 damage to each
@@ -2594,12 +2594,12 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Pokémon Power
+  - type: Poké-Body
     name: Gaseous Form
     text: Sabrina's Gastly gets +10 HP for each [P] Energy card attached to it. This
       power works even if Sabrina's Gastly is Asleep, Confused, or Paralyzed.
   moves:
-  - cost: [P, P]
+  - cost: [P, C]
     name: Suffocating Gas
     damage: '30'
   weaknesses:
@@ -2689,8 +2689,8 @@ cards:
   rarity: Rare
   text: [Attach Brock's Protection to 1 of your Pokémon with Brock in its name. Energy
       cards attached to that Pokémon can't be removed by your opponent's attacks or
-      Trainer cards (except Suppporter and G-SPEC cards). (This doesn't stop the rest of the attack or Trainer card from
-      working normally.)]
+      Trainer cards (except Suppporter and G-SPEC cards). (This doesn't stop the rest of
+      the attack or Trainer card from working normally.)]
   artist: Ken Sugimori
 - id: 187-102
   pioId: pkmod7-102
@@ -2769,8 +2769,8 @@ cards:
   text: ['Put 1 card from your hand face down onto your Bench. (You can''t play this
       card if your Bench is full.) Treat that card as a Basic Pokémon as long as it''s
       face down. Flip the card if either player ever needs to know what it is in order
-      to use an attack, a Pokémon Power, or a Trainer card. Flip the card if it ever
-      uses an attack or Pokémon Power, evolves, retreats, is damaged by an attack,
+      to use an attack, a Poké-Power, or a Trainer card. Flip the card if it ever
+      uses an attack or Poké-Power, evolves, retreats, is damaged by an attack,
       or is otherwise affected by an attack. At any time during your turn, you may
       flip the card over. When you flip that card over, if it isn''t a Basic Pokémon,
       discard it and all cards attached to it.']


### PR DESCRIPTION
Edits Pokemon-Powers to all become Poke-Powers and certain mons mentioned in the e-mail to have Poke-Bodies.

Additional mods (copy pasted from Goku's email):
* GH29 Misty's Closyter's Shell armour reduces damage by 20
* GC101 Brocks Protection Card Rule Update
* GC03 Brock's Ninetales added Poke-Power/body to shape shift 
* GC97 [P][C] Suffocating Gas attach Energy cost