### PR TITLE
Poke-Body conversions and some other updates

### DIFF
--- a/src/main/resources/cards/181-pokemod_base_set.yaml
+++ b/src/main/resources/cards/181-pokemod_base_set.yaml
@@ -220,7 +220,7 @@ cards:
   hp: 100
   retreatCost: 3
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Strikes Back
     text: Whenever your opponent's attack damages Machamp (even if Machamp is Knoced
       Out), this power does 10 damage to the attacking Pokémon. (Don't apply Weakness

--- a/src/main/resources/cards/183-pokemod_fossil.yaml
+++ b/src/main/resources/cards/183-pokemod_fossil.yaml
@@ -19,7 +19,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Prehistoric Power
     text: No more Evolution cards can be played. This power stops working while Aerodactyl
         is affected by a Special Condition.
@@ -77,7 +77,7 @@ cards:
   hp: 50
   retreatCost: 1
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Transform
     text: If Ditto is your Active Pokémon, treat it as if it were the same card as
         the Defending Pokémon, including type, Hit Points, Weakness, and so on, except
@@ -166,7 +166,7 @@ cards:
   hp: 60
   retreatCost: 0
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Transparency
     text: Whenever an attack does anything to Haunter, flip a coin. If heads, prevent
         all effects of that attack, including damage, done to Haunter. This power stops
@@ -361,7 +361,7 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Toxic Gas
     text: As long as this Pokémon has any Energy cards attached to it, ignore all Poké-Powers
         other than Toxic Gases. This power stops working while Muk is affected by
@@ -435,7 +435,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Prehistoric Power
     text: No more Evolution cards can be played. This power stops working while Aerodactyl
         is affected by a Special Condition.
@@ -493,7 +493,7 @@ cards:
   hp: 50
   retreatCost: 1
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Transform
     text: If Ditto is your Active Pokémon, treat it as if it were the same card as
         the Defending Pokémon, including type, Hit Points, Weakness, and so on, except
@@ -582,7 +582,7 @@ cards:
   hp: 60
   retreatCost: 0
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Transparency
     text: Whenever an attack does anything to Haunter, flip a coin. If heads, prevent
         all effects of that attack, including damage, done to Haunter. This power stops
@@ -777,7 +777,7 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Toxic Gas
     text: As long as this Pokémon has any Energy cards attached to it, ignore all Poké-Powers
         other than Toxic Gases. This power stops working while Muk is affected by
@@ -1367,7 +1367,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Kabuto Armor
     text: Whenever an attack (even your own) does damage to Kabuto (after applying
         Weakness and Resistance), that attack only does half the damage to Kabuto (rounded
@@ -1424,7 +1424,7 @@ cards:
   hp: 50
   retreatCost: 1
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Clairvoyance
     text: Your opponent plays with his or her hand face up. This power stops working
         while Omanyte is affected by a Special Condition.

--- a/src/main/resources/cards/185-pokemod_team_rocket.yaml
+++ b/src/main/resources/cards/185-pokemod_team_rocket.yaml
@@ -164,7 +164,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Sinkhole
     text: Whenever your opponent's Active Pokémon retreats, your opponent flips a
       coin. If tails, this power does 20 damage to that Pokémon. (Don't apply Weakness
@@ -230,7 +230,7 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Final Beam
     text: When Dark Gyarados is Knocked Out by an attack, flip a coin. If heads, this
       power does 20 damage for each [W] Energy attached to Dark Gyarados to the Pokémon
@@ -613,7 +613,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Sinkhole
     text: Whenever your opponent's Active Pokémon retreats, your opponent flips a
       coin. If tails, this power does 20 damage to that Pokémon. (Don't apply Weakness
@@ -680,7 +680,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Final Beam
     text: When Dark Gyarados is Knocked Out by an attack, flip a coin. If heads, this
       power does 20 damage for each [W] Energy attached to Dark Gyarados to the Pokémon
@@ -1136,7 +1136,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Sticky Goo
     text: As long as Dark Muk is your Active Pokémon, your opponent pays 2 more to
       retreat his or her Active Pokémon. This power stops working while Dark Muk is
@@ -1194,7 +1194,7 @@ cards:
   hp: 60
   retreatCost: 1
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Frenzy
     text: If Dark Primeape does any damage while it's Confused (even to itself), it
       does 30 more damage.

--- a/src/main/resources/cards/186-pokemod_gym_heroes.yaml
+++ b/src/main/resources/cards/186-pokemod_gym_heroes.yaml
@@ -131,7 +131,7 @@ cards:
   hp: 80
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Pollen Defense
     text: If an attack does damage to Erika's Vileplume while it's your Active Pokémon
       (even if it's Knocked Out), flip a coin. If heads, your opponent's Active Pokémon
@@ -742,9 +742,9 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Shell Armor
-    text: You may reduce all damage done by attacks to Misty's Cloyster by 10 (after
+    text: You may reduce all damage done by attacks to Misty's Cloyster by 20 (after
       applying Weakness and Resistance). (Any other effects of attacks still happen.)
       This power can't be used if Misty's Cloyster is affected by a Special Condition.
   moves:
@@ -1098,7 +1098,7 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Strange Barrier
     text: Whenever an attack by a Basic Pokémon (including your own) does 20 or more
       damage to Erika's Dratini (after applying Weakness and Resistance), reduce that

--- a/src/main/resources/cards/187-pokemod_gym_challenge.yaml
+++ b/src/main/resources/cards/187-pokemod_gym_challenge.yaml
@@ -81,7 +81,7 @@ cards:
     text: Once during your turn (before your attack), you may attach an Evolution
       card (excluding Pokémon ex) from your hand to Brock's Ninetales. (This doesn't count as evolving 
       Brock's Ninetales.) Treat Brock's Ninetales as if it were that Pokémon instead. It can't
-      evolve, devolve, or use the Poké-Power of that Pokémon. During your turn,
+      evolve, devolve, or use the Poké-Power/Body of that Pokémon. During your turn,
       you may discard the Evolution card attached to Brock's Ninetales. This power
       can't be used if Brock's Ninetales is affected by a Special Condition. If Brock's
       Ninetales becomes Asleep, Confused, or Paralyzed, discard all Evolution cards
@@ -167,7 +167,7 @@ cards:
   hp: 100
   retreatCost: 3
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Fortitude
     text: If Giovanni's Machamp would be Knocked Out by an opponent's attack, flip
       a coin. If heads, Giovanni's Machamp is not Knocked Out and its remaining HP
@@ -454,7 +454,7 @@ cards:
   hp: 80
   retreatCost: 3
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Psylink
     text: Sabrina's Alakazam always has a copy of every attack your [P] Pokémon 
       in play have (excluding Pokémon ex) (including their Energy costs and anything else required in 
@@ -530,7 +530,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Healing Fire
     text: Whenever you attach a [R] Energy card from your hand to Blaine's Ninetales,
       remove 1 damage counter from it, if it has any. This power stops working while
@@ -670,7 +670,7 @@ cards:
   hp: 80
   retreatCost: 3
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Energy Drain
     text: If an opponent's attack does damage to Koga's Muk (even if Koga's Muk is
       Knocked Out), flip a coin. If heads and if it has any, choose 1 Energy card
@@ -926,7 +926,7 @@ cards:
   hp: 70
   retreatCost: 1
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Scram
     text: If Brock's Primeape ever has exactly 10 HP left, shuffle it and all cards
       attached to it into your deck. This power stops working while Brock's Primeape
@@ -1096,7 +1096,7 @@ cards:
   hp: 60
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Relaxing Scent
     text: As long as Erika's Ivysaur is your Active Pokémon, whenever an attack (even
       your own) does damage to any Pokémon (after applying Weakness and Resistance),
@@ -1412,7 +1412,7 @@ cards:
   hp: 70
   retreatCost: 2
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Shock Blast
     text: If Lt. Surge's Electrode is your Active Pokémon and gets damaged (even if
       it's Knocked Out), flip a coin. If tails, this power does 20 damage to each
@@ -2594,12 +2594,12 @@ cards:
   hp: 40
   retreatCost: 1
   abilities:
-  - type: Poké-Power
+  - type: Poké-Body
     name: Gaseous Form
     text: Sabrina's Gastly gets +10 HP for each [P] Energy card attached to it. This
       power works even if Sabrina's Gastly is affected by a Special Condition.
   moves:
-  - cost: [P, P]
+  - cost: [P, C]
     name: Suffocating Gas
     damage: '30'
   weaknesses:

--- a/src/main/resources/cards/187-pokemod_gym_challenge.yaml
+++ b/src/main/resources/cards/187-pokemod_gym_challenge.yaml
@@ -81,7 +81,7 @@ cards:
     text: Once during your turn (before your attack), you may attach an Evolution
       card (excluding Pokémon ex) from your hand to Brock's Ninetales. (This doesn't count as evolving 
       Brock's Ninetales.) Treat Brock's Ninetales as if it were that Pokémon instead. It can't
-      evolve, devolve, or use the Poké-Power/Body of that Pokémon. During your turn,
+      evolve, devolve, or use the Poké-Power or Poké-Body of that Pokémon. During your turn,
       you may discard the Evolution card attached to Brock's Ninetales. This power
       can't be used if Brock's Ninetales is affected by a Special Condition. If Brock's
       Ninetales becomes Asleep, Confused, or Paralyzed, discard all Evolution cards


### PR DESCRIPTION
The Poke-Body changes cover Base-Gym.

Other changes mentioned in Goku's e-mail:
* GH29 Misty's Closyter's Shell armour reduces damage by 20
* GC03 Brock's Ninetales added Poke-Power/body to shape shift 
* GC97 [P][C] Suffocating Gas attach Energy cost